### PR TITLE
Lock MapResult after remove

### DIFF
--- a/htmap/exceptions.py
+++ b/htmap/exceptions.py
@@ -77,3 +77,6 @@ class CannotRenameMap(HTMapException):
 class UnknownPythonDeliveryMechanism(HTMapException):
     """The specified Python delivery mechanism has not been registered."""
     pass
+
+class MapWasRemoved(HTMapException):
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,6 @@ from htmap.settings import BASE_SETTINGS
 
 # start with base settings (ignore user settings for tests)
 htmap.settings.replace(BASE_SETTINGS)
-htmap.settings['DOCKER.IMAGE'] = 'maventree/htmap:latest'  # todo: this is bad
 
 
 @pytest.fixture(scope = 'session', autouse = True)
@@ -47,7 +46,7 @@ def delivery_methods(request):
     htmap.settings['DELIVERY_METHOD'] = request.param
 
 
-def test_get_base_options(map_id, map_dir, delivery, test_id = None):
+def get_base_options_for_tests(map_id, map_dir, delivery, test_id = None):
     opts = get_base_options_dict(map_id, map_dir, delivery)
     opts['+htmap_test_id'] = str(test_id)
 
@@ -67,7 +66,7 @@ def set_htmap_dir_and_clean_after(tmpdir_factory, mocker):
     test_id = next(ids)
     mocker.patch(
         'htmap.options.get_base_options_dict',
-        functools.partial(test_get_base_options, test_id = test_id),
+        functools.partial(get_base_options_for_tests, test_id = test_id),
     )
 
     yield

--- a/tests/test_remove_map.py
+++ b/tests/test_remove_map.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+
 import pytest
 
 import htmap
@@ -48,3 +50,22 @@ def test_remove_shortcut_on_nonexistent_map_dir_raises():
 
 def test_remove_shortcut_on_nonexistent_map_dir_fails_silently_if_not_exist_ok_set():
     htmap.remove('no_such_mapid', not_exist_ok = True)
+
+
+@pytest.mark.parametrize(
+    'method',
+    [
+        key
+        for key, val in inspect.getmembers(htmap.MapResult, predicate = inspect.isfunction)
+        if not key.startswith('_')
+    ],
+)
+def test_calling_public_methods_after_remove_raises(method, mapped_doubler):
+    result = mapped_doubler.map('method_after_remove', range(1))
+
+    result.remove()
+
+    with pytest.raises(htmap.exceptions.MapWasRemoved):
+        # some of the methods take arguments
+        # but this will actually fail before that check happens
+        getattr(result, method)()


### PR DESCRIPTION
Prevents interaction with MapResult objects via the public API after the underlying map has been removed.

Resolves #7 