### PR TITLE
Make input file transfer automatic in certain cases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-docs/build/
+docs/
 develop-eggs/
 dist/
 downloads/
@@ -104,7 +104,9 @@ venv.bak/
 .mypy_cache/
 
 .idea/
-docs/
 
 Dockerfile
 dr
+
+.github/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,6 @@ COPY docker/.htmaprc /home/${SUBMIT_USER}/.htmaprc
 # copy htmap package into container and install it
 # this is the only part that can't be cached against editing the package
 COPY --chown=mapper:mapper . /home/${SUBMIT_USER}/htmap
-RUN chmod +x /home/${SUBMIT_USER}/htmap/docker/entrypoint.sh
 WORKDIR /home/${SUBMIT_USER}/htmap
-RUN pip install --no-cache -e .
+RUN chmod +x /home/${SUBMIT_USER}/htmap/docker/entrypoint.sh \
+ && pip install --no-cache --no-deps -e .

--- a/htmap/__init__.py
+++ b/htmap/__init__.py
@@ -51,6 +51,7 @@ from .management import (
 )
 from .tags import get_tags
 from .checkpointing import checkpoint
+from .transfer import TransferPath, TransferWindowsPath, TransferPosixPath
 from . import exceptions
 
 from . import _startup

--- a/htmap/htio.py
+++ b/htmap/htio.py
@@ -51,24 +51,15 @@ def save_func(map_dir: Path, func: Callable) -> None:
 def save_inputs(
     map_dir: Path,
     args_and_kwargs: Iterator[Tuple[Tuple, Dict]],
-) -> int:
+):
     """
     Save the arguments to the mapped function to the map's input directory.
-    Returns the number of inputs to the map.
     """
     base_path = map_dir / names.INPUTS_DIR
-    num_components = 0
     for component, a_and_k in enumerate(args_and_kwargs):
         save_object(a_and_k, base_path / f'{component}.{names.INPUT_EXT}')
 
-        num_components += 1
-
-    if num_components == 0:
-        raise exceptions.EmptyMap()
-
     logger.debug(f'saved args and kwargs in {base_path}')
-
-    return num_components
 
 
 def save_num_components(map_dir: Path, num_components: int) -> None:

--- a/htmap/mapping.py
+++ b/htmap/mapping.py
@@ -288,14 +288,16 @@ def create_map(
     try:
         make_map_dir_and_subdirs(map_dir)
         htio.save_func(map_dir, func)
-        args_and_kwargs, extra_input_files = process_args_and_kwargs(args_and_kwargs)
 
+        args_and_kwargs, extra_input_files = process_args_and_kwargs(args_and_kwargs)
+        num_components = len(args_and_kwargs)
+        if num_components == 0:
+            raise exceptions.EmptyMap()
         if map_options.input_files is None and len(extra_input_files) > 0:
             map_options.input_files = [[] for _ in range(len(extra_input_files))]
         for tif, extra in zip(map_options.input_files, extra_input_files):
             tif.extend(extra)
-
-        num_components = htio.save_inputs(map_dir, args_and_kwargs)
+        htio.save_inputs(map_dir, args_and_kwargs)
 
         submit_obj, itemdata = options.create_submit_object_and_itemdata(
             tag,

--- a/htmap/options.py
+++ b/htmap/options.py
@@ -153,11 +153,8 @@ def create_submit_object_and_itemdata(
     tag: str,
     map_dir: Path,
     num_components: int,
-    map_options: Optional[MapOptions] = None,
+    map_options: MapOptions,
 ) -> Tuple[htcondor.Submit, List[Dict[str, str]]]:
-    if map_options is None:
-        map_options = MapOptions()
-
     run_delivery_setup(
         tag,
         map_dir,

--- a/htmap/transfer.py
+++ b/htmap/transfer.py
@@ -1,0 +1,20 @@
+import os
+import pathlib
+
+
+class TransferPath(pathlib.Path):
+    _flavour = pathlib._windows_flavour if os.name == 'nt' else pathlib._posix_flavour
+
+    def __new__(cls, *args, **kwargs):
+        if cls is TransferPath:
+            cls = TransferWindowsPath if os.name == 'nt' else TransferPosixPath
+
+        return super().__new__(cls, *args, **kwargs)
+
+
+class TransferWindowsPath(TransferPath):
+    pass
+
+
+class TransferPosixPath(TransferPath):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 htcondor >= 8.8.0
-cloudpickle
+cloudpickle >= 0.6.1
 toml
 tqdm
 click >= 7.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-pytest
+pytest >= 4.1.1
 pytest-mock
 pytest-xdist
 coverage

--- a/tests/integration/test_automatic_file_transfer.py
+++ b/tests/integration/test_automatic_file_transfer.py
@@ -1,0 +1,116 @@
+# Copyright 2019 HTCondor Team, Computer Sciences Department,
+# University of Wisconsin-Madison, WI.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Set
+
+import pytest
+
+from pathlib import Path
+
+import htmap
+
+TEST_FILE_NAME = 'test_file'
+
+
+@pytest.fixture(scope = 'function')
+def transfer_path(tmp_path):
+    p = htmap.TransferPath(tmp_path / TEST_FILE_NAME)
+    p.touch()
+
+    return p
+
+
+def cwd_names() -> Set[str]:
+    return {p.name for p in Path.cwd().iterdir()}
+
+
+def test_path_in_args(transfer_path):
+    m = htmap.map(lambda p: p.name in cwd_names(), [transfer_path])
+    m.wait(180)
+
+    assert m[0]
+
+
+def test_path_in_kwargs(transfer_path):
+    def func(path = None):
+        return path.name in cwd_names()
+
+    m = htmap.starmap(func, kwargs = [{'path': transfer_path}])
+    m.wait(180)
+
+    assert m[0]
+
+
+def test_multiple_paths_in_args(tmp_path):
+    paths = [
+        htmap.TransferPath(tmp_path / "test-1.txt"),
+        htmap.TransferPath(tmp_path / "test-2.txt"),
+        htmap.TransferPath(tmp_path / "test-3.txt"),
+    ]
+    for p in paths:
+        p.touch()
+
+    @htmap.mapped
+    def func(a, b, c):
+        return all(p.name in cwd_names() for p in (a, b, c))
+
+    m = func.starmap(args = [paths])
+    m.wait(180)
+
+    assert m[0]
+
+
+def test_paths_in_list_arg(transfer_path):
+    @htmap.mapped
+    def func(list_of_paths):
+        return all(p.name in cwd_names() for p in list_of_paths)
+
+    m = func.map(args = [[transfer_path]])
+    m.wait(180)
+
+    assert m[0]
+
+
+def test_paths_in_set_arg(transfer_path):
+    @htmap.mapped
+    def func(set_of_paths):
+        return all(p.name in cwd_names() for p in set_of_paths)
+
+    m = func.map(args = [{transfer_path}])
+    m.wait(180)
+
+    assert m[0]
+
+
+def test_paths_in_dict_arg(transfer_path):
+    @htmap.mapped
+    def func(dict_of_paths):
+        return all(p.name in cwd_names() for p in dict_of_paths.values())
+
+    m = func.map(args = [{'key': transfer_path}])
+    m.wait(180)
+
+    assert m[0]
+
+
+def test_duplicate_paths(transfer_path):
+    @htmap.mapped
+    def func(list_of_paths):
+        return all(p.name in cwd_names() for p in list_of_paths)
+
+    m = func.map(args = [[transfer_path, transfer_path]])
+    m.wait(180)
+
+    assert m[0]

--- a/tests/integration/test_automatic_file_transfer.py
+++ b/tests/integration/test_automatic_file_transfer.py
@@ -114,3 +114,51 @@ def test_duplicate_paths(transfer_path):
     m.wait(180)
 
     assert m[0]
+
+
+# NOTE: not all of the possible recursive combinations are tested here
+# (since there are infinitely many of them...)
+# so I've just tested the most obvious ones
+
+def test_path_in_nested_list(tmp_path):
+    @htmap.mapped
+    def func(list_of_list_of_paths):
+        return all(
+            all(p.name in cwd_names() for p in list_of_paths)
+            for list_of_paths in list_of_list_of_paths
+        )
+
+    paths = [
+        htmap.TransferPath(tmp_path / "test-1.txt"),
+        htmap.TransferPath(tmp_path / "test-2.txt"),
+        htmap.TransferPath(tmp_path / "test-3.txt"),
+    ]
+    for p in paths:
+        p.touch()
+
+    m = func.map(args = [[paths]])
+    m.wait(180)
+
+    assert m[0]
+
+
+def test_path_in_nested_dict(tmp_path):
+    @htmap.mapped
+    def func(dict_of_dict_of_paths):
+        return all(
+            all(p.name in cwd_names() for p in dict_of_paths.values())
+            for dict_of_paths in dict_of_dict_of_paths.values()
+        )
+
+    paths = [
+        htmap.TransferPath(tmp_path / "test-1.txt"),
+        htmap.TransferPath(tmp_path / "test-2.txt"),
+        htmap.TransferPath(tmp_path / "test-3.txt"),
+    ]
+    for p in paths:
+        p.touch()
+
+    m = func.map(args = [{'paths': dict(zip(range(len(paths)), paths))}])
+    m.wait(180)
+
+    assert m[0]

--- a/tests/unit/test_transfer_path.py
+++ b/tests/unit/test_transfer_path.py
@@ -1,0 +1,30 @@
+# Copyright 2019 HTCondor Team, Computer Sciences Department,
+# University of Wisconsin-Madison, WI.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import htmap
+
+
+def test_path_to_transfer_path():
+    Path(htmap.TransferPath('foobar'))
+
+
+def test_transfer_path_to_path():
+    assert htmap.TransferPath(Path('foobar'))
+
+
+def test_transfer_path_isinstance_path():
+    assert isinstance(htmap.TransferPath.cwd(), Path)

--- a/tests/unit/test_transfer_path.py
+++ b/tests/unit/test_transfer_path.py
@@ -19,12 +19,24 @@ import htmap
 
 
 def test_path_to_transfer_path():
-    Path(htmap.TransferPath('foobar'))
+    assert isinstance(Path(htmap.TransferPath('foobar')), Path)
 
 
 def test_transfer_path_to_path():
-    assert htmap.TransferPath(Path('foobar'))
+    assert isinstance(htmap.TransferPath(Path('foobar')), htmap.TransferPath)
 
 
 def test_transfer_path_isinstance_path():
     assert isinstance(htmap.TransferPath.cwd(), Path)
+
+
+def test_path_is_not_instance_of_transfer_path():
+    assert not isinstance(Path.cwd(), htmap.TransferPath)
+
+
+def test_transfer_path_is_subclass_of_path():
+    assert issubclass(htmap.TransferPath, Path)
+
+
+def path_is_not_subclass_of_transfer_path():
+    assert not issubclass(Path, htmap.TransferPath)


### PR DESCRIPTION
This PR would make this snippet work as expected:

```python
from pathlib import Path
import htmap


@htmap.mapped
def path_and_contents(path):
    return str(path), path.read_text()


paths = [
    Path.cwd() / 'requirements.txt',
    Path.cwd() / 'dr',
    Path.cwd() / 'htmap' / 'holds.py',
]

print('LOCAL')
for path in paths:
    path, contents = path_and_contents(path)
    print(f'{path} => {repr(contents)}')

print('\nMAP')
m = path_and_contents.map(paths)
for path, contents in m:
    print(f'{path} => {repr(contents)}')
```

output:

```
LOCAL
C:\Users\joshk\GitHubProjects\htmap\requirements.txt => 'htcondor >= 8.8.0\ncloudpickle\ntoml\ntqdm\nclick >= 7.0.0\nclick-didyoumean\nhalo\n'
C:\Users\joshk\GitHubProjects\htmap\dr => '#!/usr/bin/env bash\n\nCONTAINER_TAG=htmap-tests\n\nset -e\necho "Building HTMap testing container..."\ndocker build --quiet -t ${CONTAINER_TAG} .\ndocker run -it --rm ${CONTAINER_TAG} $@\n'
C:\Users\joshk\GitHubProjects\htmap\htmap\holds.py => '# Copyright 2019 HTCondor Team, Computer Sciences Department,\n# University of Wisconsin-Madison, WI.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#    http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nfrom typing import NamedTuple\n\n\nclass ComponentHold(NamedTuple):\n    """Represents an HTCondor hold on a map component."""\n\n    code: int\n    reason: str\n\n    def __str__(self):\n        return f\'[{self.code}] {self.reason}\'\n\n    def __repr__(self):\n        return f\'<{self.__class__.__name__}(code = {self.code}, reason = {self.reason}>\'\n'

MAP
requirements.txt => 'htcondor >= 8.8.0\ncloudpickle\ntoml\ntqdm\nclick >= 7.0.0\nclick-didyoumean\nhalo\n'
dr => '#!/usr/bin/env bash\n\nCONTAINER_TAG=htmap-tests\n\nset -e\necho "Building HTMap testing container..."\ndocker build --quiet -t ${CONTAINER_TAG} .\ndocker run -it --rm ${CONTAINER_TAG} $@\n'
holds.py => '# Copyright 2019 HTCondor Team, Computer Sciences Department,\n# University of Wisconsin-Madison, WI.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#    http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nfrom typing import NamedTuple\n\n\nclass ComponentHold(NamedTuple):\n    """Represents an HTCondor hold on a map component."""\n\n    code: int\n    reason: str\n\n    def __str__(self):\n        return f\'[{self.code}] {self.reason}\'\n\n    def __repr__(self):\n        return f\'<{self.__class__.__name__}(code = {self.code}, reason = {self.reason}>\'\n'
```

Note that *we did not need to explicitly provide the input file paths via `MapOptions`*. HTMap knew that since we provided a `pathlib.Path` as an argument, that file needed to transferred, and it rewrote the `Path` object that actually gets sent to the execute node so that it finds the file where HTCondor puts it.

**Important question: is this insane or beautiful? Both?**