### PR TITLE
Detect error status on terminate event

### DIFF
--- a/htmap/__init__.py
+++ b/htmap/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 from typing import Tuple as _Tuple
 import logging as _logging

--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -109,7 +109,7 @@ def _map_fg(map) -> Optional[str]:
 
     if sc[htmap.state.ComponentStatus.REMOVED] > 0:
         return 'magenta'
-    elif sc[htmap.state.ComponentStatus.HELD] > 0:
+    elif (sc[htmap.state.ComponentStatus.HELD] + sc[htmap.state.ComponentStatus.ERRORED]) > 0:
         return 'red'
     elif sc[htmap.state.ComponentStatus.COMPLETED] == len(map):
         return 'green'

--- a/htmap/management.py
+++ b/htmap/management.py
@@ -164,7 +164,7 @@ def _status(
     headers = ['Tag']
     if include_state:
         utils.read_events(maps)
-        headers += [d.short() for d in state.ComponentStatus.display_statuses()]
+        headers += [str(d) for d in state.ComponentStatus.display_statuses()]
     if include_meta:
         headers += ['Local Data', 'Max Memory', 'Max Runtime', 'Total Runtime']
 

--- a/htmap/management.py
+++ b/htmap/management.py
@@ -164,7 +164,7 @@ def _status(
     headers = ['Tag']
     if include_state:
         utils.read_events(maps)
-        headers += [str(d) for d in state.ComponentStatus.display_statuses()]
+        headers += [d.short() for d in state.ComponentStatus.display_statuses()]
     if include_meta:
         headers += ['Local Data', 'Max Memory', 'Max Runtime', 'Total Runtime']
 

--- a/htmap/state.py
+++ b/htmap/state.py
@@ -37,11 +37,13 @@ class ComponentStatus(utils.StrEnum):
     COMPLETED = 'COMPLETED'
     HELD = 'HELD'
     SUSPENDED = 'SUSPENDED'
+    ERRORED = 'ERRORED'
 
     @classmethod
     def display_statuses(cls) -> Tuple['ComponentStatus', ...]:
         return (
             cls.HELD,
+            cls.ERRORED,
             cls.IDLE,
             cls.RUNNING,
             cls.COMPLETED,
@@ -131,6 +133,12 @@ class MapState:
                     self._holds[component] = h
 
                 new_status = JOB_EVENT_STATUS_TRANSITIONS.get(event.type, None)
+
+                # the component has *terminated*, but did it error?
+                if new_status is ComponentStatus.COMPLETED:
+                    if self.map._peek_status(component) == 'ERR':
+                        new_status = ComponentStatus.ERRORED
+
                 if new_status is not None:
                     self._component_statuses[component] = new_status
 

--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -20,7 +20,7 @@ import htmap
 
 def test_all_errors_if_no_limit(cli):
     m = htmap.map(lambda x: 1 / x, [0] * 2)
-    m.wait(timeout = 180)
+    m.wait(timeout = 180, errors_ok = True)
 
     result = cli(['errors', m.tag])
 
@@ -30,7 +30,7 @@ def test_all_errors_if_no_limit(cli):
 
 def test_all_errors_if_zero_limit(cli):
     m = htmap.map(lambda x: 1 / x, [0] * 2)
-    m.wait(timeout = 180)
+    m.wait(timeout = 180, errors_ok = True)
 
     result = cli(['errors', '--limit', '0', m.tag])
 
@@ -40,7 +40,7 @@ def test_all_errors_if_zero_limit(cli):
 
 def test_one_error_if_limit_one(cli):
     m = htmap.map(lambda x: 1 / x, [0] * 2)
-    m.wait(timeout = 180)
+    m.wait(timeout = 180, errors_ok = True)
 
     result = cli(['errors', '--limit', '1', m.tag])
 

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -29,6 +29,13 @@ def mapped_div_by_x():
     return div_by_x
 
 
+def test_waiting_on_errored_component_raises():
+    m = htmap.map(lambda x: 1 / x, [0])
+
+    with pytest.raises(htmap.exceptions.MapComponentHeld):
+        m.wait(timeout = 180)
+
+
 def test_iterating_over_errored_component_raises(mapped_div_by_x):
     m = mapped_div_by_x.map(range(1))
 

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -29,15 +29,15 @@ def mapped_div_by_x():
     return div_by_x
 
 
-def test_waiting_on_errored_component_raises():
-    m = htmap.map(lambda x: 1 / x, [0])
+def test_waiting_on_errored_component_raises(mapped_div_by_x):
+    m = mapped_div_by_x.map([0])
 
-    with pytest.raises(htmap.exceptions.MapComponentHeld):
+    with pytest.raises(htmap.exceptions.MapComponentError):
         m.wait(timeout = 180)
 
 
 def test_iterating_over_errored_component_raises(mapped_div_by_x):
-    m = mapped_div_by_x.map(range(1))
+    m = mapped_div_by_x.map([0])
 
     with pytest.raises(htmap.exceptions.MapComponentError):
         list(m)
@@ -47,7 +47,7 @@ def test_error_report_has_exception_type():
     def bad(x):
         raise ZeroDivisionError
 
-    m = htmap.map(bad, range(1))
+    m = htmap.map(bad, [0])
 
     err = m.get_err(0)
 
@@ -58,7 +58,7 @@ def test_error_report_has_exception_message():
     def bad(x):
         raise Exception('foobar')
 
-    m = htmap.map(bad, range(1))
+    m = htmap.map(bad, [0])
     err = m.get_err(0)
 
     assert 'foobar' in err.report()
@@ -70,7 +70,7 @@ def test_error_report_includes_input_files():
 
     m = htmap.map(
         dummy,
-        range(1),
+        [0],
         map_options = htmap.MapOptions(
             fixed_input_files = Path(__file__),
         )


### PR DESCRIPTION
Resolve #134 : instead of blindly marking any terminated component as `Completed`, we first check whether it experienced an error. If it did, we mark it `Errored` instead. The addition has been propagated to all relevant places, including status messages and how `Map.wait` works (it will now raise an exception if a component hits an error, in addition to if a component gets held).