### PR TITLE
Event edge case cleanup

### DIFF
--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -76,7 +76,7 @@ def _start_htmap_logger():
 
     handler = logging.StreamHandler(stream = sys.stdout)
     handler.setLevel(logging.DEBUG)
-    handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    handler.setFormatter(logging.Formatter('%(asctime)s ~ %(levelname)s ~ %(name)s:%(funcName)s:%(lineno)d ~ %(message)s'))
 
     htmap_logger.addHandler(handler)
 

--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -74,7 +74,7 @@ def _start_htmap_logger():
     htmap_logger = logging.getLogger('htmap')
     htmap_logger.setLevel(logging.DEBUG)
 
-    handler = logging.StreamHandler(stream = sys.stdout)
+    handler = logging.StreamHandler(stream = sys.stderr)
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(logging.Formatter('%(asctime)s ~ %(levelname)s ~ %(name)s:%(funcName)s:%(lineno)d ~ %(message)s'))
 

--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -162,8 +162,9 @@ def status(no_state, no_meta, format, live, no_color):
         sys.exit(1)
 
     maps = sorted((_cli_load(tag) for tag in htmap.get_tags()), key = lambda m: (m.is_transient, m.tag))
-    with make_spinner(text = 'Reading map component statuses...'):
-        read_events(maps)
+    if not no_state:
+        with make_spinner(text = 'Reading map component statuses...'):
+            read_events(maps)
 
     shared_kwargs = dict(
         include_state = not no_state,

--- a/htmap/state.py
+++ b/htmap/state.py
@@ -142,6 +142,8 @@ class MapState:
                         new_status = ComponentStatus.ERRORED
 
                 if new_status is not None:
+                    if new_status is self._component_statuses[component]:
+                        logger.warning(f'component {component} of map {self.map} tried to transition into the state it is already in ({new_status})')
                     self._component_statuses[component] = new_status
 
 

--- a/htmap/state.py
+++ b/htmap/state.py
@@ -144,7 +144,7 @@ class MapState:
 
                 if new_status is not None:
                     if new_status is self._component_statuses[component]:
-                        logger.warning(f'component {component} of map {self.map} tried to transition into the state it is already in ({new_status})')
+                        logger.warning(f'component {component} of map {self.map.tag} tried to transition into the state it is already in ({new_status})')
                     self._component_statuses[component] = new_status
 
 

--- a/htmap/state.py
+++ b/htmap/state.py
@@ -31,6 +31,7 @@ class ComponentStatus(utils.StrEnum):
     An enumeration of the possible statuses that a map component can be in.
     These are mostly identical to the HTCondor job statuses of the same name.
     """
+    UNKNOWN = 'UNKNOWN'
     IDLE = 'IDLE'
     RUNNING = 'RUNNING'
     REMOVED = 'REMOVED'
@@ -72,7 +73,7 @@ class MapState:
         self._event_reader = None  # delayed until _read_events is called
         self._clusterproc_to_component: Dict[Tuple[int, int], int] = {}
 
-        self._component_statuses = [ComponentStatus.IDLE for _ in self.map.components]
+        self._component_statuses = [ComponentStatus.UNKNOWN for _ in self.map.components]
         self._holds: Dict[int, holds.ComponentHold] = {}
         self._memory_usage = [0 for _ in self.map.components]
         self._runtime = [datetime.timedelta(0) for _ in self.map.components]

--- a/htmap/state.py
+++ b/htmap/state.py
@@ -55,6 +55,8 @@ JOB_EVENT_STATUS_TRANSITIONS = {
     htcondor.JobEventType.JOB_EVICTED: ComponentStatus.IDLE,
     htcondor.JobEventType.JOB_UNSUSPENDED: ComponentStatus.IDLE,
     htcondor.JobEventType.JOB_RELEASED: ComponentStatus.IDLE,
+    htcondor.JobEventType.SHADOW_EXCEPTION: ComponentStatus.IDLE,
+    htcondor.JobEventType.JOB_RECONNECT_FAILED: ComponentStatus.IDLE,
     htcondor.JobEventType.JOB_TERMINATED: ComponentStatus.COMPLETED,
     htcondor.JobEventType.EXECUTE: ComponentStatus.RUNNING,
     htcondor.JobEventType.JOB_HELD: ComponentStatus.HELD,


### PR DESCRIPTION
Adds tracking for some more events that cause state transitions (`SHADOW_EXCEPTION` and `JOB_RECONNECT_FAILED`), which solves some of the problems from #129. Also adds a warning log message that detects (but allows) a component to transition to its current state (which should never happen unless we have missing or out-of-order events in the log.