### PR TITLE
Glob-match for Tags

### DIFF
--- a/htmap/management.py
+++ b/htmap/management.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Iterable, Dict, Union, NamedTuple, Callable, List
+from typing import Tuple, Iterable, Dict, Union, NamedTuple, Callable, List, Optional
 import logging
 
 from pathlib import Path
@@ -46,9 +46,24 @@ def load(tag: str) -> maps.Map:
     return maps.Map.load(tag)
 
 
-def load_maps() -> Tuple[maps.Map, ...]:
-    """Return a :class:`tuple` containing the :class:`Map` for all existing maps."""
-    return tuple(load(tag) for tag in tags.get_tags())
+def load_maps(pattern: Optional[str] = None) -> Tuple[maps.Map, ...]:
+    """
+    Return a :class:`tuple` containing the :class:`Map` for all existing maps,
+    with optional filtering based on a glob-style pattern.
+
+    Parameters
+    ----------
+    pattern
+        A `glob-style pattern <https://docs.python.org/3/library/fnmatch.html#module-fnmatch>`_.
+        Only maps whose tags fit the pattern will be returned.
+        If ``None`` (the default), all maps will be returned.
+
+    Returns
+    -------
+    maps :
+        A tuple contain the maps whose tags fit the ``pattern``.
+    """
+    return tuple(load(tag) for tag in tags.get_tags(pattern))
 
 
 def remove(tag: str, not_exist_ok: bool = True) -> None:

--- a/htmap/tags.py
+++ b/htmap/tags.py
@@ -1,7 +1,10 @@
+from typing import Optional
+
 import random
 import string
 from pathlib import Path
 from typing import Tuple
+import fnmatch
 
 from htmap import names, settings, exceptions
 
@@ -10,9 +13,27 @@ def tags_dir() -> Path:
     return Path(settings['HTMAP_DIR']) / names.TAGS_DIR
 
 
-def get_tags() -> Tuple[str, ...]:
-    """Return a tuple containing the ``tag`` for all existing maps."""
-    return tuple(path.name for path in tags_dir().iterdir())
+def get_tags(pattern: Optional[str] = None) -> Tuple[str, ...]:
+    """
+    Return a tuple containing the ``tag`` for all existing maps,
+    with optional filtering based on a glob-style pattern.
+
+    Parameters
+    ----------
+    pattern
+        A `glob-style pattern <https://docs.python.org/3/library/fnmatch.html#module-fnmatch>`_.
+        Only tags that fit the pattern will be returned.
+        If ``None`` (the default), all tags will be returned.
+
+    Returns
+    -------
+    tags :
+        A tuple containing the tags that match the ``pattern``.
+    """
+    return tuple(
+        path.name for path in tags_dir().iterdir()
+        if pattern is None or fnmatch.fnmatchcase(path.name, pattern)
+    )
 
 
 def tag_file_path(tag: str) -> Path:

--- a/htmap/tags.py
+++ b/htmap/tags.py
@@ -57,6 +57,9 @@ INVALID_TAG_CHARACTERS = {
     '?',
     '*',
     ' ',
+    '[',
+    ']',
+    '!',
 }
 
 

--- a/tests/integration/test_management.py
+++ b/tests/integration/test_management.py
@@ -20,12 +20,34 @@ import pytest
 import htmap
 
 
-def test_tags(mapped_doubler):
+def test_get_tags(mapped_doubler):
     mapped_doubler.map(range(1), tag = 'a')
     mapped_doubler.map(range(1), tag = 'b')
     mapped_doubler.map(range(1), tag = 'c')
 
     assert set(htmap.get_tags()) == {'a', 'b', 'c'}
+
+
+@pytest.mark.parametrize(
+    'tags, pattern, expected',
+    [
+        (('a', 'b', 'c'), None, ('a', 'b', 'c')),  # None = no filter
+        (('a', 'b', 'c'), 'a', ('a',)),
+        (('a', 'b', 'c'), '?', ('a', 'b', 'c')),
+        (('a', 'b', 'c'), '[ab]', ('a', 'b')),
+        (('a', 'b', 'c'), '[!ab]', ('c',)),
+        (('a', 'b', 'c'), '??', ()),
+        (('a', 'b', 'cc'), '??', ('cc',)),
+        (('a1', 'b1', 'c1'), '?1', ('a1','b1','c1')),
+        (('a1', 'bbb1', 'cc1'), '*1', ('a1', 'bbb1','cc1')),
+        (('A',), 'a', ()),  # case-sensitive
+    ]
+)
+def test_get_tag_with_pattern(mapped_doubler, tags, pattern, expected):
+    for tag in tags:
+        mapped_doubler.map(range(1), tag = tag)
+
+    assert set(htmap.get_tags(pattern)) == set(expected)
 
 
 def test_load_maps_finds_all_maps(mapped_doubler):


### PR DESCRIPTION
Adds the ability to select maps by glob-style pattern matching on their tags in the `get_tags()` and `load_maps()` functions, as well as in the CLI commands that use those functions.