### PR TITLE
v0.4.4

### DIFF
--- a/docs/source/versions/v0_4_4.rst
+++ b/docs/source/versions/v0_4_4.rst
@@ -1,0 +1,22 @@
+v0.4.4
+======
+
+New Features
+------------
+
+Bug Fixes
+---------
+
+* In execution error reports, local variables with very long string forms are
+  now cut down to a smaller size.
+
+Known Issues
+------------
+
+* Execution errors that result in the job being terminated but no output being
+  produced are still not handled entirely gracefully. Right now, the component
+  state will just show as ``ERRORED``, but there won't be an actual error report.
+* Map component state may become corrupted when a map is manually vacated.
+  Force-removal may be needed to clean up maps if HTCondor and HTMap disagree
+  about the state of their components.
+  Issue: https://github.com/htcondor/htmap/issues/129

--- a/htmap/errors.py
+++ b/htmap/errors.py
@@ -108,7 +108,10 @@ class ComponentError:
             row.append(self._indent('\nLocal variables:\n', multiple = 2))
             if frame.locals:
                 for name, value in sorted(frame.locals.items()):
-                    row.append(self._indent(f'{name} = {value}\n', multiple = 3))
+                    v = str(value)
+                    if len(v) > 45:
+                        v = v[:20] + ' ... ' + v[-20:]
+                    row.append(self._indent(f'{name} = {v}\n', multiple = 3))
             result.append(''.join(row))
         if count > _RECURSIVE_CUTOFF:
             count -= _RECURSIVE_CUTOFF

--- a/htmap/version.py
+++ b/htmap/version.py
@@ -15,7 +15,7 @@
 
 from typing import Tuple
 
-__version__ = '0.4.3'
+__version__ = '0.4.4'
 
 
 def version() -> str:


### PR DESCRIPTION
Small change: print only the first and last characters of very long variables in tracebacks, to improve readability of execution error reports.