### PR TITLE
Test infrastructure update

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch = True
 
-data_file = /tmp/htmap-test-coverage/.coverage
+data_file = /tmp/htmap-test-coverage
 
 include =
     htmap/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 branch = True
 
+data_file = /tmp/htmap-test-coverage/.coverage
+
 include =
     htmap/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
 env:
   - HTCONDOR_VERSION=8.8
   - HTCONDOR_VERSION=8.9
@@ -17,7 +16,10 @@ jobs:
   fast_finish: true
 
 install:
-  - travis_retry docker build -t htmap-test --file tests/_inf/Dockerfile --build-arg HTCONDOR_VERSION --build-arg PYTHON_VERSION=${TRAVIS_PYTHON_VERSION/dev/rc} .
+  - travis_retry docker build -t htmap-test --file tests/_inf/Dockerfile --build-arg HTCONDOR_VERSION --build-arg PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} .
 
 script:
-  - docker run --mount type=bind,src="$PWD",dst=/home/mapper/htmap htmap-test bash tests/_inf/travis.sh
+  - docker run --mount type=bind,src="$PWD",dst=/home/mapper/htmap htmap-test pytest -n 2 --cov=./
+
+after_script:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: python
 python:
   - "3.6"
   - "3.7"
-  - "3.8"
+#  - "3.8"
 env:
   - HTCONDOR_VERSION=8.8
   - HTCONDOR_VERSION=8.9
@@ -19,7 +19,7 @@ install:
   - travis_retry docker build -t htmap-test --file tests/_inf/Dockerfile --build-arg HTCONDOR_VERSION --build-arg PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} .
 
 script:
-  - docker run --mount type=bind,src="$PWD",dst=/home/mapper/htmap htmap-test pytest -n 2 --cov=./
+  - docker run --mount type=bind,src="$PWD",dst=/home/mapper/htmap htmap-test pytest -n 2 --cov
 
 after_script:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,4 @@ install:
   - travis_retry docker build -t htmap-test --file tests/_inf/Dockerfile --build-arg HTCONDOR_VERSION --build-arg PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} .
 
 script:
-  - docker run --mount type=bind,src="$PWD",dst=/home/mapper/htmap htmap-test pytest -n 2 --cov
-
-after_script:
-  - codecov
+  - docker run --mount type=bind,src="$PWD",dst=/home/mapper/htmap,readonly htmap-test bash tests/_inf/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
   fast_finish: true
 
 install:
-  - pip install --user codecov
+  - pip install codecov
   - travis_retry docker build -t htmap-test --file tests/_inf/Dockerfile --build-arg HTCONDOR_VERSION --build-arg PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
   fast_finish: true
 
 install:
+  - pip install --user codecov
   - travis_retry docker build -t htmap-test --file tests/_inf/Dockerfile --build-arg HTCONDOR_VERSION --build-arg PYTHON_VERSION=${TRAVIS_PYTHON_VERSION} .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+os: linux
 dist: xenial
-sudo: required
 services:
   - docker
 
@@ -7,15 +7,17 @@ language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9-dev"
 env:
   - HTCONDOR_VERSION=8.8
   - HTCONDOR_VERSION=8.9
 
-matrix:
+jobs:
   fast_finish: true
 
 install:
-  - travis_retry docker build -t htmap-test --file tests/_inf/Dockerfile --build-arg HTCONDOR_VERSION --build-arg PYTHON_VERSION=$TRAVIS_PYTHON_VERSION .
+  - travis_retry docker build -t htmap-test --file tests/_inf/Dockerfile --build-arg HTCONDOR_VERSION --build-arg PYTHON_VERSION=${TRAVIS_PYTHON_VERSION/dev/rc} .
 
 script:
-  - docker run htmap-test tests/_inf/travis.sh
+  - docker run --mount type=bind,src="$PWD",dst=/home/mapper/htmap htmap-test bash tests/_inf/travis.sh

--- a/dr
+++ b/dr
@@ -5,4 +5,4 @@ CONTAINER_TAG=htmap-tests
 set -e
 echo "Building HTMap testing container..."
 docker build --quiet -t ${CONTAINER_TAG} --file tests/_inf/Dockerfile .
-docker run -it --rm ${CONTAINER_TAG} $@
+docker run -it --rm --mount type=bind,src="$PWD",dst=/home/mapper/htmap,readonly ${CONTAINER_TAG} $@

--- a/dr
+++ b/dr
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CONTAINER_TAG=htmap-tests
+CONTAINER_TAG='htmap-tests'
 
 set -e
 echo "Building HTMap testing container..."

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@
 testspaths = tests
 
 console_output_style = count
+
+cache_dir = /tmp/htmap-pytest-cache

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ pytest >= 4.1.1
 pytest-mock
 pytest-xdist
 pytest-timeout
+pytest-watch
 coverage
 pytest-cov
 codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-timeout
 pytest-watch
 coverage < 5
 pytest-cov
+codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ pytest-mock
 pytest-xdist
 pytest-timeout
 pytest-watch
-coverage < 5
+coverage
 pytest-cov
 codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,5 @@ pytest-mock
 pytest-xdist
 pytest-timeout
 pytest-watch
-coverage
+coverage < 5
 pytest-cov
-codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 htcondor >= 8.8.0
 cloudpickle ~= 1.2
-toml ~= 0.10.0
+toml ~= 0.10
 tqdm ~= 4.36
 click ~= 7.0
-click-didyoumean == 0.0.3
-halo == 0.0.28
+click-didyoumean ~= 0.0.3
+halo ~= 0.0.28

--- a/tests/_inf/Dockerfile
+++ b/tests/_inf/Dockerfile
@@ -15,12 +15,11 @@
 
 # this dockerfile builds a test environment for HTMap
 
-ARG PYTHON_VERSION=3.7
+ARG PYTHON_VERSION=3.6
 FROM python:${PYTHON_VERSION}
 
 # build config
-ARG HTCONDOR_VERSION=8.9
-ARG MINICONDA_VERSION=latest
+ARG HTCONDOR_VERSION=8.8
 
 # switch to root to do root-level config
 USER root

--- a/tests/_inf/Dockerfile
+++ b/tests/_inf/Dockerfile
@@ -15,15 +15,15 @@
 
 # this dockerfile builds a test environment for HTMap
 
-FROM ubuntu:bionic
+ARG PYTHON_VERSION=3.7
+FROM python:${PYTHON_VERSION}
+
+# build config
+ARG HTCONDOR_VERSION=8.9
+ARG MINICONDA_VERSION=latest
 
 # switch to root to do root-level config
 USER root
-
-# build config
-ARG PYTHON_VERSION=3.7
-ARG HTCONDOR_VERSION=8.9
-ARG MINICONDA_VERSION=latest
 
 # environment setup
 ENV DEBIAN_FRONTEND=noninteractive
@@ -41,50 +41,39 @@ ENV LC_ALL=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8
 
 # install HTCondor version specified in config
-RUN wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
- && echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/${HTCONDOR_VERSION}/bionic bionic contrib" >> /etc/apt/sources.list \
+RUN wget -qO - https://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add - \
+ && echo "deb http://research.cs.wisc.edu/htcondor/debian/${HTCONDOR_VERSION}/buster buster contrib" >> /etc/apt/sources.list.d/htcondor.list \
  && apt-get -y update \
  && apt-get -y install --no-install-recommends htcondor \
  && apt-get -y clean \
  && rm -rf /var/lib/apt/lists/*
 
-# create a user to be our submitter and set conda install location
-ENV SUBMIT_USER=mapper
-ENV CONDA_DIR=/home/${SUBMIT_USER}/conda
-ENV PATH=${CONDA_DIR}/bin:${PATH}
+# copy entrypoint into place and make executable
+COPY tests/_inf/entrypoint.sh /.entrypoint.sh
+RUN chmod +x /.entrypoint.sh
+
+# create a user, set their PATH and PYTHONPATH
+ENV SUBMIT_USER=mapper \
+    PATH="/home/mapper/.local/bin:${PATH}" \
+    PYTHONPATH="/home/mapper/htmap:${PYTHONPATH}"
 RUN groupadd ${SUBMIT_USER} \
  && useradd -m -g ${SUBMIT_USER} ${SUBMIT_USER}
 
-# switch to submit user, don't need root anymore
+# switch to the user, don't need root anymore
 USER ${SUBMIT_USER}
 
-# install miniconda and python version specified in config
-# (and ipython, which is nice for debugging inside the container)
-RUN cd /tmp \
- && wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh \
- && bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR \
- && rm Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh \
- && conda install python=${PYTHON_VERSION} ipython \
- && conda clean -y --all
-
-# install htmap dependencies early for docker build caching
-COPY requirements* /home/${SUBMIT_USER}/
-RUN pip install --no-cache-dir -r /home/${SUBMIT_USER}/requirements-dev.txt \
- && pip install --no-cache-dir --upgrade htcondor==${HTCONDOR_VERSION}.* \
- && rm /home/${SUBMIT_USER}/requirements*
-
-# set default entrypoint and command
-# the entrypoint is critical: it starts HTCondor in the container
-ENTRYPOINT ["tests/_inf/entrypoint.sh"]
-CMD ["pytest"]
+# install htmap dependencies and debugging tools early for docker build caching
+COPY requirements* /tmp/
+RUN pip install --user --no-cache-dir -r /tmp/requirements-dev.txt \
+ && pip install --user --no-cache-dir ipython \
+ && pip install --user --no-cache-dir --upgrade htcondor==${HTCONDOR_VERSION}.*
 
 # copy HTCondor and HTMap testing configs into place
 COPY tests/_inf/condor_config.local /etc/condor/condor_config.local
 COPY tests/_inf/.htmaprc /home/${SUBMIT_USER}/.htmaprc
 
-# copy htmap package into container and install it
-# this is the only part that can't be cached against editing the package
-COPY --chown=mapper:mapper . /home/${SUBMIT_USER}/htmap
-RUN chmod +x /home/${SUBMIT_USER}/htmap/tests/_inf/entrypoint.sh /home/${SUBMIT_USER}/htmap/tests/_inf/travis.sh \
- && pip install --no-cache-dir --no-deps -e /home/${SUBMIT_USER}/htmap
+# set default entrypoint and command
+# the entrypoint is critical: it starts HTCondor in the container
 WORKDIR /home/${SUBMIT_USER}/htmap
+ENTRYPOINT ["/.entrypoint.sh"]
+CMD ["pytest"]

--- a/tests/_inf/condor_config.local
+++ b/tests/_inf/condor_config.local
@@ -22,18 +22,21 @@ SHADOW_QUEUE_UPDATE_INTERVAL=10
 UPDATE_INTERVAL=5
 RUNBENCHMARKS=0
 
-# Don't use all the machine resources
-RESERVED_MEMORY = ( $(DETECTED_MEMORY) / 2 )
+# Put all of the machine resources under a single partitionable slot
+NUM_SLOTS = 1
+NUM_SLOTS_TYPE_1 = 1
+SLOT_TYPE_1 = 100%
+SLOT_TYPE_1_PARTITIONABLE = TRUE
+
 JOB_RENICE_INCREMENT=5
 SCHED_UNIV_RENICE_INCREMENT=5
 SHADOW_RENICE_INCREMENT=5
 
-# If the job does not explicitly set an environment, define
-# some default environment variables that put Conda in the path.
-JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) SetCondaVars
-JOB_TRANSFORM_SetCondaVars @=end
+# Get the HTMap source into the Python path
+JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) SetPyVars
+JOB_TRANSFORM_SetPyVars @=end
 [
   Requirements = ((Env?:"") == "") && ((Environment?:"") == "");
-  set_Environment = "PATH=/home/mapper/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CONDA_DIR=/home/mapper/conda";
+  set_Environment = "PYTHONPATH=/home/mapper/htmap";
 ]
 @end

--- a/tests/_inf/condor_config.local
+++ b/tests/_inf/condor_config.local
@@ -37,6 +37,6 @@ JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) SetPyVars
 JOB_TRANSFORM_SetPyVars @=end
 [
   Requirements = ((Env?:"") == "") && ((Environment?:"") == "");
-  set_Environment = "PYTHONPATH=/home/mapper/htmap";
+  set_Environment = "PATH=/home/mapper/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PYTHONPATH=/home/mapper/htmap";
 ]
 @end

--- a/tests/_inf/entrypoint.sh
+++ b/tests/_inf/entrypoint.sh
@@ -8,13 +8,15 @@ mkdir -p "$_condor_local_dir/lock" "$_condor_local_dir/log" "$_condor_local_dir/
 
 # start condor
 condor_master
-echo "HTCondor is starting..."
+echo "Starting HTCondor..."
 
-# wait until the scheduler is awake
-while [[ ! -f ${_condor_local_dir}/spool/job_queue.log ]]
+# once the shared port daemon wakes up, use condor_who to wait for condor to stand up
+while [[ ! -s "${_condor_local_dir}/log/SharedPortLog" ]]
 do
   sleep .01
 done
+sleep 1  # fudge factor to let shared port *actually* wake up
+condor_who -wait:60 'IsReady && STARTD_State =?= "Ready"' > /dev/null
 
 if [[ -n $@ ]];
 then

--- a/tests/_inf/travis.sh
+++ b/tests/_inf/travis.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-echo condor_version
-pytest -n 6 --cov
-
-codecov -t 492519e2-1bcf-4e8a-8a3e-e28be5d9de8d

--- a/tests/_inf/travis.sh
+++ b/tests/_inf/travis.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo condor_version
+pytest -n 2 --cov
+
+codecov -t 492519e2-1bcf-4e8a-8a3e-e28be5d9de8d

--- a/tests/_inf/travis.sh
+++ b/tests/_inf/travis.sh
@@ -2,7 +2,11 @@
 
 set -e
 
-echo condor_version
-pytest -n 2 --cov
+python -c "import htcondor; print(htcondor.version())"
+pytest --version
 
-codecov -t 492519e2-1bcf-4e8a-8a3e-e28be5d9de8d
+pytest -n 2 --cov --durations=20
+
+coverage xml -o /tmp/coverage.xml
+
+codecov -t 492519e2-1bcf-4e8a-8a3e-e28be5d9de8d -f /tmp/coverage.xml

--- a/tests/_inf/travis.sh
+++ b/tests/_inf/travis.sh
@@ -5,7 +5,7 @@ set -e
 python -c "import htcondor; print(htcondor.version())"
 pytest --version
 
-pytest -n 2 --cov --durations=20
+pytest -n 4 --cov --durations=20
 
 coverage xml -o /tmp/coverage.xml
 

--- a/tests/integration/test_checkpointing.py
+++ b/tests/integration/test_checkpointing.py
@@ -21,6 +21,7 @@ import pytest
 import htmap
 
 
+@pytest.mark.timeout(120)
 def test_checkpoint_file_exists_after_restart():
     @htmap.mapped
     def test(_):
@@ -50,6 +51,7 @@ def test_checkpoint_file_exists_after_restart():
     assert m[0] is True
 
 
+@pytest.mark.timeout(120)
 def test_checkpoint_file_has_expected_contents_after_restart():
     @htmap.mapped
     def test(_):

--- a/tests/unit/test_delivery_method_setup.py
+++ b/tests/unit/test_delivery_method_setup.py
@@ -21,6 +21,6 @@ import htmap
 from htmap.options import run_delivery_setup
 
 
-def test_unknown_delivery_method_raises():
+def test_unknown_delivery_method_for_delivery_setup_raises(tmp_path):
     with pytest.raises(htmap.exceptions.UnknownPythonDeliveryMethod):
-        run_delivery_setup('foo', Path.cwd(), 'definitely-not-real')
+        run_delivery_setup('foo', tmp_path, 'definitely-not-real')

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -64,9 +64,8 @@ def test_request_disk_for_str():
     assert opts['request_disk'] == '1.2GB'
 
 
-def test_single_shared_input_file():
+def test_single_shared_input_file(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 1
     map_options = htmap.MapOptions(
         fixed_input_files = ['foo.txt'],
@@ -74,7 +73,7 @@ def test_single_shared_input_file():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -82,9 +81,8 @@ def test_single_shared_input_file():
     assert 'foo.txt' in sub['transfer_input_files']
 
 
-def test_single_shared_input_file_can_be_single_str():
+def test_single_shared_input_file_can_be_single_str(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 1
     map_options = htmap.MapOptions(
         fixed_input_files = 'foo.txt',
@@ -92,7 +90,7 @@ def test_single_shared_input_file_can_be_single_str():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -100,9 +98,8 @@ def test_single_shared_input_file_can_be_single_str():
     assert 'foo.txt' in sub['transfer_input_files']
 
 
-def test_two_shared_input_files():
+def test_two_shared_input_files(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 1
     map_options = htmap.MapOptions(
         fixed_input_files = ['foo.txt', 'bar.txt'],
@@ -110,7 +107,7 @@ def test_two_shared_input_files():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -119,9 +116,8 @@ def test_two_shared_input_files():
     assert 'bar.txt' in sub['transfer_input_files']
 
 
-def test_list_of_list_of_str_input_files():
+def test_list_of_list_of_str_input_files(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 3
     map_options = htmap.MapOptions(
         input_files = [['foo.txt'], ['bar.txt'], ['buz.txt']],
@@ -129,7 +125,7 @@ def test_list_of_list_of_str_input_files():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -143,9 +139,8 @@ def test_list_of_list_of_str_input_files():
     assert itemdata == expected
 
 
-def test_list_of_str_input_files():
+def test_list_of_str_input_files(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 3
     map_options = htmap.MapOptions(
         input_files = ['foo.txt', 'bar.txt', 'buz.txt'],
@@ -153,7 +148,7 @@ def test_list_of_str_input_files():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -167,9 +162,8 @@ def test_list_of_str_input_files():
     assert itemdata == expected
 
 
-def test_list_of_path_input_files():
+def test_list_of_path_input_files(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 3
     map_options = htmap.MapOptions(
         input_files = [Path('foo.txt'), Path('bar.txt'), Path('buz.txt')],
@@ -177,7 +171,7 @@ def test_list_of_path_input_files():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -191,9 +185,8 @@ def test_list_of_path_input_files():
     assert itemdata == expected
 
 
-def test_list_of_list_of_path_input_files():
+def test_list_of_list_of_path_input_files(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 3
     map_options = htmap.MapOptions(
         input_files = [
@@ -205,7 +198,7 @@ def test_list_of_list_of_path_input_files():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -219,9 +212,8 @@ def test_list_of_list_of_path_input_files():
     assert itemdata == expected
 
 
-def test_fewer_components_than_input_files():
+def test_fewer_components_than_input_files(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 1
     map_options = htmap.MapOptions(
         input_files = [['foo.txt'], ['bar.txt'], ['buz.txt']],
@@ -230,7 +222,7 @@ def test_fewer_components_than_input_files():
     with pytest.raises(htmap.exceptions.MisalignedInputData) as exc_info:
         create_submit_object_and_itemdata(
             tag,
-            map_dir,
+            tmp_path,
             num_components,
             map_options,
         )
@@ -238,9 +230,8 @@ def test_fewer_components_than_input_files():
     assert 'input_files' in exception_msg(exc_info)
 
 
-def test_fewer_input_files_than_components():
+def test_fewer_input_files_than_components(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 5
     map_options = htmap.MapOptions(
         input_files = [['foo.txt']],
@@ -249,7 +240,7 @@ def test_fewer_input_files_than_components():
     with pytest.raises(htmap.exceptions.MisalignedInputData) as exc_info:
         create_submit_object_and_itemdata(
             tag,
-            map_dir,
+            tmp_path,
             num_components,
             map_options,
         )
@@ -257,65 +248,52 @@ def test_fewer_input_files_than_components():
     assert 'input_files' in exception_msg(exc_info)
 
 
-@pytest.mark.parametrize(
-    'rm',
-    [
-        ['239MB'],
-    ]
-)
-def test_list_request_memory(rm):
+def test_list_request_memory(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
-    num_components = 1
+    num_components = 2
     map_options = htmap.MapOptions(
-        request_memory = rm,
+        request_memory = ['239MB', '136MB'],
     )
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
 
     expected = [
         {'component': '0', 'itemdata_for_request_memory': '239MB'},
+        {'component': '1', 'itemdata_for_request_memory': '136MB'},
     ]
 
     assert itemdata == expected
 
 
-@pytest.mark.parametrize(
-    'rd',
-    [
-        ['239GB'],
-    ]
-)
-def test_list_request_disk(rd):
+def test_list_request_disk(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
-    num_components = 1
+    num_components = 2
     map_options = htmap.MapOptions(
-        request_disk = rd,
+        request_disk = ['239MB', '136MB'],
     )
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
 
     expected = [
-        {'component': '0', 'itemdata_for_request_disk': '239GB'},
+        {'component': '0', 'itemdata_for_request_disk': '239MB'},
+        {'component': '1', 'itemdata_for_request_disk': '136MB'},
     ]
 
     assert itemdata == expected
 
 
-def test_generic_itemdata():
+def test_generic_itemdata(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 3
     map_options = htmap.MapOptions(
         stooge = ['larry', 'moe', 'curly'],
@@ -323,7 +301,7 @@ def test_generic_itemdata():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -337,9 +315,8 @@ def test_generic_itemdata():
     assert itemdata == expected
 
 
-def test_generic_itemdata_too_few():
+def test_generic_itemdata_too_few(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 1
     map_options = htmap.MapOptions(
         stooge = ['larry', 'moe'],
@@ -348,7 +325,7 @@ def test_generic_itemdata_too_few():
     with pytest.raises(htmap.exceptions.MisalignedInputData) as exc_info:
         create_submit_object_and_itemdata(
             tag,
-            map_dir,
+            tmp_path,
             num_components,
             map_options,
         )
@@ -404,9 +381,8 @@ def test_option_from_settings_is_visible_in_base_options():
     assert opts['zing'] == 'hit'
 
 
-def test_url_in_fixed_input_files():
+def test_url_in_fixed_input_files(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 1
     url = 'http://www.baz.test'
     map_options = htmap.MapOptions(
@@ -415,7 +391,7 @@ def test_url_in_fixed_input_files():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -423,9 +399,8 @@ def test_url_in_fixed_input_files():
     assert url in sub['transfer_input_files']
 
 
-def test_url_in_input_files():
+def test_url_in_input_files(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 1
     url = 'http://www.baz.test'
     map_options = htmap.MapOptions(
@@ -434,7 +409,7 @@ def test_url_in_input_files():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -442,9 +417,8 @@ def test_url_in_input_files():
     assert url in itemdata[0]['extra_input_files']
 
 
-def test_two_urls_in_input_files():
+def test_two_urls_in_input_files(tmp_path):
     tag = 'foo'
-    map_dir = Path().cwd()
     num_components = 1
     url_1 = 'http://www.baz.test'
     url_2 = 'http://www.bong.test'
@@ -454,7 +428,7 @@ def test_two_urls_in_input_files():
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )
@@ -463,9 +437,9 @@ def test_two_urls_in_input_files():
     assert url_2 in itemdata[0]['extra_input_files']
 
 
-def test_unknown_delivery_mechanism():
+def test_unknown_delivery_mechanism_for_base_descriptors_raises(tmp_path):
     with pytest.raises(htmap.exceptions.UnknownPythonDeliveryMethod):
-        get_base_descriptors('foo', Path.cwd(), delivery = 'unknown')
+        get_base_descriptors('foo', tmp_path, delivery = 'unknown')
 
 
 @pytest.mark.parametrize(
@@ -479,9 +453,8 @@ def test_unknown_delivery_mechanism():
         'My.foo',
     ]
 )
-def test_custom_options(key):
+def test_custom_options(key, tmp_path):
     tag = 'test'
-    map_dir = Path().cwd()
     num_components = 1
     map_options = htmap.MapOptions(
         custom_options = {key: 'bar'},
@@ -489,7 +462,7 @@ def test_custom_options(key):
 
     sub, itemdata = create_submit_object_and_itemdata(
         tag,
-        map_dir,
+        tmp_path,
         num_components,
         map_options,
     )


### PR DESCRIPTION
Revise test infrastructure to use some better, more modern (i.e., not six months old!) practices.

Should result in a cleaner, faster test suite by minimizing Docker build time. Codecov integration should be more reliable.