### PR TITLE
Add CLI command htmap --version

### DIFF
--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -26,7 +26,7 @@ import re
 from pathlib import Path
 
 import htmap
-from htmap import names
+from htmap import names, __version__
 from htmap.management import _status
 from htmap.utils import read_events
 
@@ -61,6 +61,11 @@ CONTEXT_SETTINGS = dict(help_option_names = ['-h', '--help'])
     is_flag = True,
     default = False,
     help = 'Show log messages as the CLI runs.',
+)
+@click.version_option(
+    version = __version__,
+    prog_name = "HTMap",
+    message = '%(prog)s version %(version)s',
 )
 def cli(verbose):
     """HTMap command line tools."""

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -22,3 +22,9 @@ def test_version(cli):
     result = cli(['version'])
 
     assert htmap.version() in result.output
+
+
+def test_dash_dash_version(cli):
+    result = cli(['--version'])
+
+    assert htmap.version() in result.output


### PR DESCRIPTION
We already have `htmap version`, but it's a little odd that we don't have `htmap --version`. So now we do.