### PR TITLE
Use "shared" delivery for tests

### DIFF
--- a/docker/.htmaprc
+++ b/docker/.htmaprc
@@ -1,1 +1,1 @@
-DELIVERY_METHOD = "assume"
+DELIVERY_METHOD = "shared"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,12 +61,12 @@ RUN groupadd ${SUBMIT_USER} \
 # switch to the user, don't need root anymore
 USER ${SUBMIT_USER}
 
-# install htmap dependencies and debugging tools early for docker build caching
+# install dependencies and debugging tools early for docker build caching
 COPY requirements* /tmp/
 RUN python -m pip install --user --no-cache-dir -r /tmp/requirements-dev.txt -r /tmp/requirements-docs.txt ipython \
  && python -m pip install --user --no-cache-dir --upgrade htcondor==${HTCONDOR_VERSION}.*
 
-# copy HTCondor and HTMap testing configs into place
+# copy testing configs into place
 COPY docker/condor_config.local /etc/condor/condor_config.local
 COPY --chown=mapper:mapper docker/.htmaprc /home/${SUBMIT_USER}/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@
 
 # this dockerfile builds a test environment for HTMap
 
-ARG PYTHON_VERSION=3.6
+ARG PYTHON_VERSION=3.7
 FROM python:${PYTHON_VERSION}
 
 # build config

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@
 
 # this dockerfile builds a test environment for HTMap
 
-ARG PYTHON_VERSION=3.7
+ARG PYTHON_VERSION=3.6
 FROM python:${PYTHON_VERSION}
 
 # build config

--- a/docker/condor_config.local
+++ b/docker/condor_config.local
@@ -33,6 +33,7 @@ SCHED_UNIV_RENICE_INCREMENT=5
 SHADOW_RENICE_INCREMENT=5
 
 # Get the HTMap source into the Python path
+# We do this instead of doing an editable pip install because we don't necessarily want to write to the git dir
 JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) SetPyVars
 JOB_TRANSFORM_SetPyVars @=end
 [

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,11 +4,7 @@ testspaths = tests
 
 console_output_style = count
 
-log_format = %(levelname)-8s  %(asctime)s  %(message)s
-log_date_format = %Y-%m-%d %H:%M:%S
-
 cache_dir = /tmp/htmap-pytest-cache
 
 markers =
     issue: marks a test as corresponding to a particular GitHub issue
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest >= 4.1.1
+pytest
 pytest-mock
 pytest-xdist
 pytest-timeout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ from htmap._startup import ensure_htmap_dir_exists
 
 # start with base settings (ignore user settings for tests)
 htmap.settings.replace(BASE_SETTINGS)
-htmap.settings['DELIVERY_METHOD'] = 'assume'  # assume is the default for all tests that aren't parametric
+htmap.settings['DELIVERY_METHOD'] = 'shared'  # shared is the default for all tests that aren't parametric
 htmap.settings['WAIT_TIME'] = 0.1
 htmap.settings['MAP_OPTIONS.request_memory'] = '10MB'
 
@@ -53,7 +53,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--delivery",
         nargs = "+",
-        default = ['assume'],  # assume is the default for parametric delivery testing
+        default = ['shared'],  # shared is the default for parametric delivery testing
     )
 
 
@@ -65,22 +65,16 @@ def pytest_generate_tests(metafunc):
         )
 
 
-MAP_DIRS = []
-
-
 @pytest.fixture(scope = 'function', autouse = True)
-def set_htmap_dir(tmpdir_factory):
+def set_htmap_dir_and_clean(tmpdir_factory):
     map_dir = Path(tmpdir_factory.mktemp('htmap_dir'))
-    MAP_DIRS.append(map_dir)
+
     htmap.settings['HTMAP_DIR'] = map_dir
     ensure_htmap_dir_exists()
 
+    yield
 
-@pytest.fixture(scope = 'session', autouse = True)
-def cleanup():
-    for map_dir in MAP_DIRS:
-        htmap.settings['HTMAP_DIR'] = map_dir
-        htmap.clean(all = True)
+    htmap.clean(all = True)
 
 
 @pytest.fixture(scope = 'session')

--- a/tests/integration/test_late_materialization.py
+++ b/tests/integration/test_late_materialization.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import htmap
 
+TIMEOUT = 300
+
 
 @pytest.fixture(scope = 'function')
 def late_noop():
@@ -30,15 +32,7 @@ def late_noop():
     return noop
 
 
-@pytest.mark.timeout(10)
-def test_can_be_removed_immediately(late_noop):
-    m = late_noop.map(range(1000))
-
-    m.remove()
-
-    assert m.is_removed
-
-
+@pytest.mark.timeout(TIMEOUT)
 def test_wait_with_late_materialization(late_noop):
     m = late_noop.map(range(3))
 
@@ -60,6 +54,7 @@ def test_wait_with_late_materialization(late_noop):
     except:
         print('failed to get digest file')
 
-    m.wait(timeout = 180)
+    m.wait()
+
 
     assert m.is_done

--- a/tests/integration/test_late_materialization.py
+++ b/tests/integration/test_late_materialization.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-
 import pytest
+
+import subprocess
+from pathlib import Path
 
 import htmap
 
@@ -40,6 +41,24 @@ def test_can_be_removed_immediately(late_noop):
 
 def test_wait_with_late_materialization(late_noop):
     m = late_noop.map(range(3))
+
+    try:
+        cid = m._cluster_ids[0]
+
+        digest = Path(
+            subprocess.run(
+                ["condor_q", "-factory", str(cid)],
+                stdout = subprocess.PIPE,
+                text = True
+            ).stdout.splitlines()[-1].split()[-1]
+        ).read_text()
+        items = Path(digest.splitlines()[-1].split()[-1]).read_text()
+
+        print(digest)
+        print()
+        print(items)
+    except:
+        print('failed to get digest file')
 
     m.wait(timeout = 180)
 


### PR DESCRIPTION
This makes it much easier to test locally without a Docker container, if desired.