### PR TITLE
API, DOC: clarify "remove" command/function

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -3,6 +3,16 @@ FAQ
 
 .. py:currentmodule:: htmap
 
+How do I abort a job?
+---------------------
+
+For example, say you mistakenly launch some jobs, and want want to abort the
+job, fix some input parameters, then relaunch it.
+
+The right CLI command is ``htmap remove foo``, or the HTMap function
+:func:`~htmap.remove`. This mirrors the HTCondor API and will remove the job
+from the job scheduler regardless of state (running, waiting, held, etc).
+
 .. _successful-jobs:
 
 How do I only process completed jobs?

--- a/docs/source/tips-and-tricks.rst
+++ b/docs/source/tips-and-tricks.rst
@@ -52,7 +52,23 @@ This command shows the status of each job for various tags:
    htmap status --live  # See live display of info on each job (and their tags)
 
 This might indicate that 4 jobs in tag ``foo`` are completed and 2 are idle (or
-waiting to be run).  These commands will show more information about individual
+waiting to be run).
+
+This command completely deletes the map with tag ``foo``, including removing
+any jobs that are in any state (running, idle, held, whatever). Use this if you
+want to completely resubmit the map from scratch, without any previous state.
+
+.. code::
+
+   htmap remove foo
+
+This commands keeps the jobs in the queue, but prevents them from running. This allowed editing them  and lets you edit them live.
+
+.. code::
+
+   htmap hold foo
+
+These commands will show more information about individual
 maps and map components:
 
 .. code::

--- a/docs/source/tips-and-tricks.rst
+++ b/docs/source/tips-and-tricks.rst
@@ -60,7 +60,7 @@ want to completely resubmit the map from scratch, without any previous state.
 
 .. code::
 
-   htmap remove foo
+   htmap abort foo
 
 This commands keeps the jobs in the queue, but prevents them from running. This allowed editing them  and lets you edit them live.
 

--- a/docs/source/tips-and-tricks.rst
+++ b/docs/source/tips-and-tricks.rst
@@ -60,7 +60,7 @@ want to completely resubmit the map from scratch, without any previous state.
 
 .. code::
 
-   htmap abort foo
+   htmap remove foo
 
 This commands keeps the jobs in the queue, but prevents them from running. This allowed editing them  and lets you edit them live.
 

--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -380,9 +380,13 @@ def wait(tags, pattern, all):
 )
 def remove(tags, pattern, all, force):
     """
-    This command removes a map.
-    All data associated with a removed map is permanently deleted and all
-    components are removed from the HTCondor queue.
+    This command removes a map from the Condor queue. Functionally, this
+    command aborts a job.
+
+    This function will completely remove a map from the Condor
+    queue regardless of job state (running, executing, waiting, etc).
+    All data associated with a removed map is permanently deleted.
+
     """
     tags = _get_tags(all, pattern, tags)
 

--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -370,28 +370,27 @@ def wait(tags, pattern, all):
         return
 
 
-@cli.command(short_help = "Abort maps; all components will be removed from the queue and all data associated with the maps will be permanently deleted.")
+@cli.command(short_help = "Remove maps; all components will be removed from the queue and all data associated with the maps will be permanently deleted.")
 @_multi_tag_args
 @click.option(
     '--force',
     is_flag = True,
     default = False,
-    help = 'Do not wait for HTCondor to abort the map components before removing local data.',
+    help = 'Do not wait for HTCondor to remove the map components before removing local data.',
 )
-def abort(tags, pattern, all, force):
+def remove(tags, pattern, all, force):
     """
-    This command aborts a map.
-
+    This command removes a map.
     All data associated with a removed map is permanently deleted and all
-    components are removed from the HTCondor queue, regardless of what state they're in (running, idle, held, etc).
+    components are removed from the HTCondor queue.
     """
     tags = _get_tags(all, pattern, tags)
 
     for tag in tags:
-        with make_spinner(f'Aborting map {tag} ...') as spinner:
+        with make_spinner(f'Removing map {tag} ...') as spinner:
             _cli_load(tag).remove(force = force)
 
-            spinner.succeed(f'Successfully aborted map {tag}')
+            spinner.succeed(f'Removed map {tag}')
 
 
 @cli.command(short_help = "Hold maps; components will be prevented from running until released.")

--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -370,27 +370,28 @@ def wait(tags, pattern, all):
         return
 
 
-@cli.command(short_help = "Remove maps; all components will be removed from the queue and all data associated with the maps will be permanently deleted.")
+@cli.command(short_help = "Abort maps; all components will be removed from the queue and all data associated with the maps will be permanently deleted.")
 @_multi_tag_args
 @click.option(
     '--force',
     is_flag = True,
     default = False,
-    help = 'Do not wait for HTCondor to remove the map components before removing local data.',
+    help = 'Do not wait for HTCondor to abort the map components before removing local data.',
 )
-def remove(tags, pattern, all, force):
+def abort(tags, pattern, all, force):
     """
-    This command removes a map.
+    This command aborts a map.
+
     All data associated with a removed map is permanently deleted and all
-    components are removed from the HTCondor queue.
+    components are removed from the HTCondor queue, regardless of what state they're in (running, idle, held, etc).
     """
     tags = _get_tags(all, pattern, tags)
 
     for tag in tags:
-        with make_spinner(f'Removing map {tag} ...') as spinner:
+        with make_spinner(f'Aborting map {tag} ...') as spinner:
             _cli_load(tag).remove(force = force)
 
-            spinner.succeed(f'Removed map {tag}')
+            spinner.succeed(f'Successfully aborted map {tag}')
 
 
 @cli.command(short_help = "Hold maps; components will be prevented from running until released.")

--- a/htmap/maps.py
+++ b/htmap/maps.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 def _protector(method):
     @functools.wraps(method)
     def _protect(self, *args, **kwargs):
-        if self.is_removed:
+        if not self.exists:
             raise exceptions.MapWasRemoved(f'Cannot call {method} for map {self.tag} because it has been removed')
         return method(self, *args, **kwargs)
 
@@ -799,8 +799,12 @@ class Map(collections.abc.Sequence):
         logger.error(f'Failed to remove map directory for map {self.tag}, run htmap.clean() to try to remove later')
 
     @property
-    def is_removed(self) -> bool:
-        return not self._map_dir.exists()
+    def exists(self) -> bool:
+        """
+        True if and only if files related to the tag exist on the
+        scheduler node.
+        """
+        return self._map_dir.exists()
 
     def hold(self) -> None:
         """

--- a/htmap/maps.py
+++ b/htmap/maps.py
@@ -728,9 +728,12 @@ class Map(collections.abc.Sequence):
 
     def remove(self, force: bool = False) -> None:
         """
-        This command removes a map.
-        All data associated with a removed map is permanently deleted and all
-        components are removed from the HTCondor queue.
+        This command removes a map from the Condor queue. Functionally, this
+        command aborts a job.
+
+        This function will completely remove a map from the Condor
+        queue regardless of job state (running, executing, waiting, etc).
+        All data associated with a removed map is permanently deleted.
 
         Parameters
         ----------

--- a/tests/cli/test_clean.py
+++ b/tests/cli/test_clean.py
@@ -31,7 +31,7 @@ def test_clean_removes_transient_map(cli):
 
     result = cli(['clean'])
 
-    assert m.is_removed
+    assert not m.exists
 
 
 def test_clean_has_tags_of_all_maps_removed(cli):
@@ -55,7 +55,7 @@ def test_clean_removes_multiple_transient_maps(cli):
 
     result = cli(['clean'])
 
-    assert all(m.is_removed for m in maps)
+    assert all(not m.exists for m in maps)
 
 
 def test_clean_does_not_remove_persistent_map_by_default(cli):
@@ -63,7 +63,7 @@ def test_clean_does_not_remove_persistent_map_by_default(cli):
 
     result = cli(['clean'])
 
-    assert not m.is_removed
+    assert m.exists
 
 
 def test_clean_with_all_removes_persistent_maps(cli):
@@ -71,4 +71,4 @@ def test_clean_with_all_removes_persistent_maps(cli):
 
     result = cli(['clean', '--all'])
 
-    assert m.is_removed
+    assert not m.exists

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -21,7 +21,7 @@ import htmap
 def test_map_is_removed(cli):
     m = htmap.map(str, range(1))
 
-    result = cli(['remove', m.tag])
+    result = cli(['abort', m.tag])
 
     assert m.is_removed
 
@@ -32,7 +32,7 @@ def test_remove_multiple_maps(cli):
         htmap.map(str, range(1)),
     ]
 
-    result = cli(['remove', *(m.tag for m in maps)])
+    result = cli(['abort', *(m.tag for m in maps)])
 
     assert all(m.is_removed for m in maps)
 
@@ -43,7 +43,7 @@ def test_remove_all(cli):
         htmap.map(str, range(1)),
     ]
 
-    result = cli(['remove', '--all'])
+    result = cli(['abort', '--all'])
 
     assert all(m.is_removed for m in maps)
 
@@ -54,7 +54,7 @@ def test_remove_multiple_maps_message_has_tags(cli):
         htmap.map(str, range(1)),
     ]
 
-    result = cli(['remove', *(m.tag for m in maps)])
+    result = cli(['abort', *(m.tag for m in maps)])
 
     assert all(m.tag in result.output for m in maps)
 
@@ -65,6 +65,6 @@ def test_remove_all_message_has_tags(cli):
         htmap.map(str, range(1)),
     ]
 
-    result = cli(['remove', '--all'])
+    result = cli(['abort', '--all'])
 
     assert all(m.tag in result.output for m in maps)

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -18,12 +18,12 @@ import pytest
 import htmap
 
 
-def test_map_is_removed(cli):
+def test_map_exists(cli):
     m = htmap.map(str, range(1))
 
     result = cli(['abort', m.tag])
 
-    assert m.is_removed
+    assert not m.exists
 
 
 def test_remove_multiple_maps(cli):
@@ -34,7 +34,7 @@ def test_remove_multiple_maps(cli):
 
     result = cli(['abort', *(m.tag for m in maps)])
 
-    assert all(m.is_removed for m in maps)
+    assert all(not m.exists for m in maps)
 
 
 def test_remove_all(cli):
@@ -45,7 +45,7 @@ def test_remove_all(cli):
 
     result = cli(['abort', '--all'])
 
-    assert all(m.is_removed for m in maps)
+    assert all(not m.exists for m in maps)
 
 
 def test_remove_multiple_maps_message_has_tags(cli):

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -21,7 +21,7 @@ import htmap
 def test_map_exists(cli):
     m = htmap.map(str, range(1))
 
-    result = cli(['abort', m.tag])
+    result = cli(['remove', m.tag])
 
     assert not m.exists
 
@@ -32,7 +32,7 @@ def test_remove_multiple_maps(cli):
         htmap.map(str, range(1)),
     ]
 
-    result = cli(['abort', *(m.tag for m in maps)])
+    result = cli(['remove', *(m.tag for m in maps)])
 
     assert all(not m.exists for m in maps)
 
@@ -43,7 +43,7 @@ def test_remove_all(cli):
         htmap.map(str, range(1)),
     ]
 
-    result = cli(['abort', '--all'])
+    result = cli(['remove', '--all'])
 
     assert all(not m.exists for m in maps)
 
@@ -54,7 +54,7 @@ def test_remove_multiple_maps_message_has_tags(cli):
         htmap.map(str, range(1)),
     ]
 
-    result = cli(['abort', *(m.tag for m in maps)])
+    result = cli(['remove', *(m.tag for m in maps)])
 
     assert all(m.tag in result.output for m in maps)
 
@@ -65,6 +65,6 @@ def test_remove_all_message_has_tags(cli):
         htmap.map(str, range(1)),
     ]
 
-    result = cli(['abort', '--all'])
+    result = cli(['remove', '--all'])
 
     assert all(m.tag in result.output for m in maps)

--- a/tests/integration/test_remove_map.py
+++ b/tests/integration/test_remove_map.py
@@ -56,7 +56,7 @@ def test_map_is_marked_as_removed_after_calling_remove(mapped_doubler):
 
     m.remove()
 
-    assert m.is_removed
+    assert not m.exists
 
 
 @pytest.mark.parametrize(
@@ -98,4 +98,4 @@ def test_can_force_remove_map_without_contacting_schedd(mapped_doubler, mocker):
 
     m.remove(force = True)
 
-    assert m.is_removed
+    assert not m.exists


### PR DESCRIPTION
**What does this PR implement?**
It does a couple things:

* Renames CLI command and HTMap function "remove" to "abort"
* Renames HTMap map attribute `is_removed` to `exists` (and adds documentation and changes tests to reflect boolean flip).
* Adds documentation note about `htmap abort`

**Reference issues/PRs**
This PR resolve #220.