### PR TITLE
V0.6.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,15 @@ repos:
     rev: v2.0.0
     hooks:
       - id: hadolint
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.11.0
+    hooks:
+      - id: setup-cfg-fmt
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v2.2.0
+    hooks:
+      - id: seed-isort-config
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.3.2
+    hooks:
+      - id: isort

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,6 +67,6 @@ ENTRYPOINT ["/home/mapper/htmap/docker/entrypoint.sh"]
 CMD ["bash"]
 
 COPY --chown=mapper:mapper . /home/${USER}/htmap
-RUN python -m pip install --user --no-cache-dir --disable-pip-version-check "/home/${USER}/htmap[tests,docs]" htcondor==${HTCONDOR_VERSION}.*
+RUN python -m pip install --user --no-cache-dir --disable-pip-version-check --use-feature=2020-resolver "/home/${USER}/htmap[tests,docs]" htcondor==${HTCONDOR_VERSION}.*
 
 WORKDIR /home/${USER}/htmap

--- a/docs/source/versions/v0_6_1.rst
+++ b/docs/source/versions/v0_6_1.rst
@@ -1,0 +1,28 @@
+v0.6.1
+======
+
+.. py:currentmodule:: htmap
+
+
+This version is a drop-in replacement for v0.6.0, except that it relaxes the
+version requirements for several dependencies to accommodate upcoming changes
+to the
+`pip dependency resolver <https://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html>`_.
+
+
+Known Issues
+------------
+
+* HTMap does not currently allow "directory content transfers", which is an HTCondor
+  feature where naming a directory in ``transfer_input_files`` with a trailing
+  slash transfers the contents of the directory, not the directory itself.
+  (If you try it, the directory itself will be transferred, as if you had not
+  used a trailing slash).
+  Issue: :issue:`215`
+* Execution errors that result in the job being terminated but no output being
+  produced are still not handled entirely gracefully. Right now, the component
+  state will just show as ``ERRORED``, but there won't be an actual error report.
+* Map component state may become corrupted when a map is manually vacated.
+  Force-removal may be needed to clean up maps if HTCondor and HTMap disagree
+  about the state of their components.
+  Issue: :issue:`129`

--- a/htmap/__init__.py
+++ b/htmap/__init__.py
@@ -16,47 +16,34 @@
 
 import logging as _logging
 
+from .settings import BASE_SETTINGS, USER_SETTINGS, settings
 from .version import __version__, version, version_info
-
-from .settings import settings, USER_SETTINGS, BASE_SETTINGS
 
 # SET UP NULL LOG HANDLER
 _logger = _logging.getLogger(__name__)
 _logger.setLevel(_logging.DEBUG)
 _logger.addHandler(_logging.NullHandler())
 
-from .mapping import (
-    map,
-    starmap,
-    build_map,
-    MapBuilder,
-)
-from .mapped import mapped, MappedFunction
-from .maps import (
-    Map,
-    MapStdOut,
-    MapStdErr,
-    MapOutputFiles,
-)
-from .holds import ComponentHold
+from . import _startup, exceptions
+from .checkpointing import checkpoint
 from .errors import ComponentError
-from .state import ComponentStatus
-from .options import MapOptions, register_delivery_method
+from .holds import ComponentHold
 from .management import (
-    status,
-    status_json,
-    status_csv,
+    Transplant,
+    clean,
     load,
     load_maps,
     remove,
-    clean,
-    Transplant,
-    transplants,
+    status,
+    status_csv,
+    status_json,
     transplant_info,
+    transplants,
 )
+from .mapped import MappedFunction, mapped
+from .mapping import MapBuilder, build_map, map, starmap
+from .maps import Map, MapOutputFiles, MapStdErr, MapStdOut
+from .options import MapOptions, register_delivery_method
+from .state import ComponentStatus
 from .tags import get_tags
-from .checkpointing import checkpoint
 from .transfer import TransferPath, transfer_output_files
-from . import exceptions
-
-from . import _startup

--- a/htmap/__main__.py
+++ b/htmap/__main__.py
@@ -1,5 +1,4 @@
 from .cli import cli
 
-
 if __name__ == "__main__":
     exit(cli.main(prog_name="htmap"))

--- a/htmap/_startup.py
+++ b/htmap/_startup.py
@@ -1,9 +1,9 @@
-import os
 import logging
+import os
 from logging import handlers
 from pathlib import Path
 
-from . import settings, names
+from . import names, settings
 
 logger = logging.getLogger("htmap")
 

--- a/htmap/checkpointing.py
+++ b/htmap/checkpointing.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import os
-from pathlib import Path
 import shutil
+from pathlib import Path
 
 from . import names
 

--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -13,27 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List, Collection, Tuple
-
+import collections
+import functools
 import logging
+import random
+import shutil
 import sys
 import time
-import collections
-import random
-import functools
-import shutil
 from pathlib import Path
-
-import htcondor
-import htmap
-from htmap import names, __version__
-from htmap.management import _status, read_events
+from typing import Collection, List, Optional, Tuple
 
 import click
+import htcondor
 from click_didyoumean import DYMGroup
-
 from halo import Halo
 from spinners import Spinners
+
+import htmap
+from htmap import __version__, names
+from htmap.management import _status, read_events
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/htmap/htio.py
+++ b/htmap/htio.py
@@ -13,12 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Iterator, Callable, Iterable
-import logging
-
 import gzip
 import json
+import logging
 from pathlib import Path
+from typing import Any, Callable, Iterable, Iterator, List
 
 import cloudpickle
 import htcondor

--- a/htmap/management.py
+++ b/htmap/management.py
@@ -13,21 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Iterable, Dict, Union, NamedTuple, Callable, List, Optional
-import logging
-
-from pathlib import Path
-import datetime
 import collections
-import json
 import csv
+import datetime
 import io
-import textwrap
+import json
+import logging
 import shutil
+import textwrap
 import uuid
 from concurrent.futures.thread import ThreadPoolExecutor
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
 
-from . import maps, tags, mapping, utils, state, names, settings, exceptions
+from . import exceptions, mapping, maps, names, settings, state, tags, utils
 
 logger = logging.getLogger(__name__)
 

--- a/htmap/mapped.py
+++ b/htmap/mapped.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Dict, Union, Optional, Callable, Any
 import logging
+from typing import Any, Callable, Dict, Iterable, Optional, Union
 
-from . import mapping, options, maps
+from . import mapping, maps, options
 
 logger = logging.getLogger(__name__)
 

--- a/htmap/mapping.py
+++ b/htmap/mapping.py
@@ -13,30 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Iterable, Dict, Optional, Callable, Iterator, Any, List, Union
-import logging
-
-import uuid
-import shutil
-from pathlib import Path
 import itertools
+import logging
+import shutil
+import uuid
+from pathlib import Path
 from pprint import pformat
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
 import htcondor
 
-from . import (
-    htio,
-    tags,
-    exceptions,
-    maps,
-    transfer,
-    options,
-    condor,
-    settings,
-    names,
-    utils,
-)
-from .types import KWARGS, ARGS_OR_KWARGS, ARGS_AND_KWARGS, ARGS
+from . import condor, exceptions, htio, maps, names, options, settings, tags, transfer, utils
+from .types import ARGS, ARGS_AND_KWARGS, ARGS_OR_KWARGS, KWARGS
 
 logger = logging.getLogger(__name__)
 

--- a/htmap/maps.py
+++ b/htmap/maps.py
@@ -13,48 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import (
-    Tuple,
-    List,
-    Iterable,
-    Any,
-    Optional,
-    Iterator,
-    Dict,
-    Mapping,
-    MutableMapping,
-)
-import logging
-
-import datetime
-import shutil
-import time
-import functools
-import inspect
 import collections
 import collections.abc
+import datetime
+import functools
+import inspect
+import logging
+import shutil
+import time
 import weakref
 from copy import copy
 from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Tuple
 
+import classad
+import htcondor
 from tqdm import tqdm
 
-import htcondor
-import classad
-
-from . import (
-    htio,
-    state,
-    tags,
-    errors,
-    holds,
-    mapping,
-    condor,
-    settings,
-    utils,
-    names,
-    exceptions,
-)
+from . import condor, errors, exceptions, holds, htio, mapping, names, settings, state, tags, utils
 
 logger = logging.getLogger(__name__)
 

--- a/htmap/options.py
+++ b/htmap/options.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Iterable, Optional, Callable, Dict, List, Tuple
-import logging
-
-import sys
-import shutil
 import collections
 import hashlib
+import logging
+import shutil
+import sys
 from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import htcondor
 
-from . import utils, transfer, exceptions, names, settings
-from .types import TRANSFER_PATH, REMAPS
+from . import exceptions, names, settings, transfer, utils
+from .types import REMAPS, TRANSFER_PATH
 
 logger = logging.getLogger(__name__)
 

--- a/htmap/run/_htmap_run.py
+++ b/htmap/run/_htmap_run.py
@@ -15,16 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import getpass
+import gzip
 import os
 import shutil
-import sys
 import socket
-import datetime
-import gzip
+import subprocess
+import sys
 import textwrap
 import traceback
-import subprocess
-import getpass
 from pathlib import Path
 
 TRANSFER_DIR = "_htmap_transfer"

--- a/htmap/run/_htmap_transfer_plugin.py
+++ b/htmap/run/_htmap_transfer_plugin.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
+import contextlib
+import pickle
 import subprocess
 import sys
 import textwrap
-import contextlib
-import pickle
 import traceback
 from pathlib import Path
 
-import htcondor
 import classad
+import htcondor
 
 TRANSFER_PLUGIN_CACHE = "_htmap_transfer_plugin_cache"
 USER_URL_TRANSFER_DIR = "_htmap_user_url_transfer"

--- a/htmap/settings.py
+++ b/htmap/settings.py
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any, Optional
-import logging
-
-import os
-import itertools
 import functools
-from pathlib import Path
+import itertools
+import logging
+import os
 from copy import copy
+from pathlib import Path
+from typing import Any, Optional, Union
 
 import toml
 

--- a/htmap/state.py
+++ b/htmap/state.py
@@ -13,17 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Tuple, List
-import logging
-
 import datetime
-import threading
+import logging
 import pickle
+import threading
 from pathlib import Path
+from typing import Dict, List, Tuple
 
 import htcondor
 
-from . import holds, names, utils, exceptions
+from . import exceptions, holds, names, utils
 
 logger = logging.getLogger(__name__)
 

--- a/htmap/tags.py
+++ b/htmap/tags.py
@@ -13,15 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
+import fnmatch
 import random
 import string
 from pathlib import Path
-from typing import Tuple
-import fnmatch
+from typing import Optional, Tuple
 
-from htmap import names, settings, exceptions
+from htmap import exceptions, names, settings
 
 
 def tags_dir() -> Path:

--- a/htmap/transfer.py
+++ b/htmap/transfer.py
@@ -13,17 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union, Tuple
-
-import os
-import shutil
 import functools
+import os
 import pickle
-
+import shutil
 from pathlib import Path
+from typing import Optional, Tuple, Union
 from urllib.parse import urlunsplit
 
-from . import names, utils, exceptions
+from . import exceptions, names, utils
 
 
 @functools.total_ordering

--- a/htmap/types.py
+++ b/htmap/types.py
@@ -1,6 +1,5 @@
-from typing import Dict, Any, Union, Tuple, Mapping
-
 import os
+from typing import Any, Dict, Mapping, Tuple, Union
 
 from htmap import transfer
 

--- a/htmap/utils.py
+++ b/htmap/utils.py
@@ -13,32 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import (
-    Optional,
-    Union,
-    Iterable,
-    Any,
-    Mapping,
-    MutableMapping,
-    Callable,
-    Dict,
-    Tuple,
-)
-import logging
-
-import os
-import time
 import datetime
+import enum
+import logging
+import os
+import re
 import subprocess
 import sys
-import enum
-import re
+import time
 from pathlib import Path
-
-from . import exceptions
+from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping, Optional, Tuple, Union
 
 import htcondor
 from classad import ClassAd
+
+from . import exceptions
 
 MutableMapping.register(ClassAd)
 

--- a/htmap/version.py
+++ b/htmap/version.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 try:
     from importlib import metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,9 @@ build-backend = "setuptools.build_meta"
 line-length = 100
 target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
+
+[tool.isort]
+known_third_party = ["classad", "click", "click_didyoumean", "cloudpickle", "halo", "htcondor", "pytest", "setuptools", "sphinx_rtd_theme", "spinners", "toml", "tqdm"]
+line_length = 100
+multi_line_output = "VERTICAL_HANGING_INDENT"
+include_trailing_comma = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,8 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 100
 target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
-
-[build-system]
-requires = ["setuptools >= 40.6.0", "wheel"]
-build-backend = "setuptools.build_meta"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 
-testspaths = tests
+testpaths = tests
 
 console_output_style = count
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = htmap
-version = 0.6.0
+version = 0.6.1
 description = High-Throughput Computing in Python, powered by HTCondor
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,21 +1,21 @@
 [metadata]
 name = htmap
 version = 0.6.0
-author = Josh Karpel
-author_email = josh.karpel@gmail.com
 description = High-Throughput Computing in Python, powered by HTCondor
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/htcondor/htmap
-license = ASL 2.0
+author = Josh Karpel
+author_email = josh.karpel@gmail.com
+license = Apache-2.0
 license_file = LICENSE
 classifiers =
-    License :: OSI Approved :: Apache Software License
     Development Status :: 3 - Alpha
-    Programming Language :: Python :: 3
-    Intended Audience :: Science/Research
     Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
+    Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -26,45 +26,45 @@ classifiers =
 packages =
     htmap
     htmap.run
+install_requires =
+    click>=7.0
+    click-didyoumean>=0.0.3
+    cloudpickle>=1.4
+    halo>=0.0.30
+    htcondor>=8.8
+    toml>=0.10
+    tqdm>=4.46
+    importlib-metadata>=1.0;python_version < "3.8"
 python_requires = >=3.6
 include_package_data = True
-install_requires =
-    htcondor >= 8.8
-    cloudpickle >= 1.4
-    toml >= 0.10
-    tqdm >= 4.46
-    click >= 7.0
-    click-didyoumean>=0.0.3
-    halo>=0.0.30
-    importlib-metadata >= 1.0; python_version < "3.8"
-
-[options.extras_require]
-tests =
-    pytest>=6
-    pytest-mock
-    pytest-xdist
-    pytest-timeout
-    pytest-watch
-    pytest-profiling
-    coverage
-    pytest-cov
-    codecov
-    pre-commit
-docs =
-    sphinx
-    sphinx_rtd_theme
-    sphinx_autodoc_typehints
-    pygments-github-lexers
-    ipython
-    nbsphinx
-    nbstripout
-    sphinx-click
-    sphinx-issues
-    sphinx-autobuild
 
 [options.entry_points]
 console_scripts =
     htmap = htmap.cli:cli
+
+[options.extras_require]
+docs =
+    ipython
+    nbsphinx
+    nbstripout
+    pygments-github-lexers
+    sphinx
+    sphinx-autobuild
+    sphinx-click
+    sphinx-issues
+    sphinx_autodoc_typehints
+    sphinx_rtd_theme
+tests =
+    codecov
+    coverage
+    pre-commit
+    pytest>=6
+    pytest-cov
+    pytest-mock
+    pytest-profiling
+    pytest-timeout
+    pytest-watch
+    pytest-xdist
 
 [options.package_data]
 * =

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,17 +30,17 @@ python_requires = >=3.6
 include_package_data = True
 install_requires =
     htcondor >= 8.8
-    cloudpickle ~= 1.4
-    toml ~= 0.10
-    tqdm ~= 4.46
-    click ~= 7.0
-    click-didyoumean
-    halo
-    importlib-metadata ~= 1.0; python_version < "3.8"
+    cloudpickle >= 1.4
+    toml >= 0.10
+    tqdm >= 4.46
+    click >= 7.0
+    click-didyoumean>=0.0.3
+    halo>=0.0.30
+    importlib-metadata >= 1.0; python_version < "3.8"
 
 [options.extras_require]
 tests =
-    pytest
+    pytest>=6
     pytest-mock
     pytest-xdist
     pytest-timeout

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -16,7 +16,6 @@
 import functools
 
 import pytest
-
 from click.testing import CliRunner
 
 from htmap.cli import cli as htmap_cli

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,15 +14,14 @@
 # limitations under the License.
 
 import time
-from pathlib import Path
 from copy import copy
+from pathlib import Path
 
 import pytest
 
 import htmap
-from htmap.settings import BASE_SETTINGS
-
 from htmap._startup import ensure_htmap_dir_exists
+from htmap.settings import BASE_SETTINGS
 
 # start with base settings (ignore user settings for tests)
 htmap.settings.replace(BASE_SETTINGS)

--- a/tests/integration/test_checkpointing.py
+++ b/tests/integration/test_checkpointing.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 import time
+from pathlib import Path
 
 import pytest
 

--- a/tests/integration/test_errors_and_holds.py
+++ b/tests/integration/test_errors_and_holds.py
@@ -15,11 +15,10 @@
 
 from pathlib import Path
 
+import htcondor
 import pytest
 
 import htmap
-
-import htcondor
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/test_late_materialization.py
+++ b/tests/integration/test_late_materialization.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import time
-
 from pathlib import Path
 
-import htmap
 import htcondor
+import pytest
+
+import htmap
 
 TIMEOUT = 300
 

--- a/tests/integration/test_rerun.py
+++ b/tests/integration/test_rerun.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 import time
 from pathlib import Path
+
+import pytest
 
 import htmap
 

--- a/tests/integration/user_file_transfer/test_automatic_input_file_transfer.py
+++ b/tests/integration/user_file_transfer/test_automatic_input_file_transfer.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from typing import Set
 
 import pytest
-
-from pathlib import Path
 
 import htmap
 

--- a/tests/integration/user_file_transfer/test_fixed_input_files.py
+++ b/tests/integration/user_file_transfer/test_fixed_input_files.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 import htmap
 

--- a/tests/integration/user_file_transfer/test_output_files.py
+++ b/tests/integration/user_file_transfer/test_output_files.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 import htmap
 

--- a/tests/integration/user_file_transfer/test_output_remaps.py
+++ b/tests/integration/user_file_transfer/test_output_remaps.py
@@ -14,14 +14,13 @@
 # limitations under the License.
 
 
-import pytest
-
 from pathlib import Path
+
+import htcondor
+import pytest
 
 import htmap
 from htmap import utils
-
-import htcondor
 
 TIMEOUT = 300
 

--- a/tests/integration/user_file_transfer/test_url_input_transfer.py
+++ b/tests/integration/user_file_transfer/test_url_input_transfer.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 import htmap
 

--- a/tests/integration/user_file_transfer/test_url_output_transfer.py
+++ b/tests/integration/user_file_transfer/test_url_output_transfer.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 
 
-import pytest
-
 from pathlib import Path
+
+import htcondor
+import pytest
 
 import htmap
 from htmap import utils
-import htcondor
 
 TIMEOUT = 300
 

--- a/tests/unit/test_base_descriptors.py
+++ b/tests/unit/test_base_descriptors.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 import htmap
 from htmap.options import (

--- a/tests/unit/test_delivery_method_base_descriptors.py
+++ b/tests/unit/test_delivery_method_base_descriptors.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 import htmap
 from htmap.options import get_base_descriptors

--- a/tests/unit/test_delivery_method_setup.py
+++ b/tests/unit/test_delivery_method_setup.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 import htmap
 from htmap.options import run_delivery_setup

--- a/tests/unit/test_htio.py
+++ b/tests/unit/test_htio.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from pathlib import Path
 
 import htcondor
+import pytest
 
 from htmap import htio
 

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -16,10 +16,10 @@
 from pathlib import Path
 
 import pytest
-from tests.conftest import exception_msg
 
 import htmap
 from htmap.options import create_submit_object_and_itemdata, get_base_descriptors
+from tests.conftest import exception_msg
 
 
 def test_one_reserved_kwarg_raises():

--- a/tests/unit/test_transfer_path.py
+++ b/tests/unit/test_transfer_path.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 from htmap import TransferPath
 

--- a/tests/unit/test_transform_args_and_kwargs.py
+++ b/tests/unit/test_transform_args_and_kwargs.py
@@ -13,16 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from pathlib import Path
 
+import pytest
+
 from htmap import TransferPath
-from htmap.mapping import (
-    transform_args_and_kwargs,
-    transform_input_paths,
-    transform_input_path,
-)
+from htmap.mapping import transform_args_and_kwargs, transform_input_path, transform_input_paths
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_wait_for_path_to_exist.py
+++ b/tests/unit/test_wait_for_path_to_exist.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
+
 import htmap
-from htmap.utils import wait_for_path_to_exist, timeout_to_seconds
+from htmap.utils import timeout_to_seconds, wait_for_path_to_exist
 
 
 def test_returns_when_path_does_exist():


### PR DESCRIPTION
This is the tracking PR for v0.6.1, which mainly exists to ensure compatibility with the new `pip` dependency resolver https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020.

It will also include a few infrastructure changes because I happened to be in `setup.cfg` and noticed we didn't have `pre-commit` checks for it.