### PR TITLE
Apply workaround for issues with job event logs in AFS (HTCONDOR-463)

### DIFF
--- a/htmap/state.py
+++ b/htmap/state.py
@@ -112,7 +112,7 @@ class MapState:
         with self._event_reader_lock:  # no thread can be in here at the same time as another
             if self._event_reader is None:
                 logger.debug(f"Created event log reader for map {self.map.tag}")
-                self._event_reader = htcondor.JobEventLog(self._event_log_path.as_posix()).events(0)
+                self._event_reader = htcondor.JobEventLog(self._event_log_path.as_posix())
 
             with utils.Timer() as timer:
                 handled_events = self._handle_events()
@@ -133,7 +133,7 @@ class MapState:
         """
         handled_events = 0
 
-        for event in self._event_reader:
+        for event in self._event_reader.events(1):
             handled_events += 1
 
             # skip the late materialization submit event

--- a/htmap/state.py
+++ b/htmap/state.py
@@ -133,7 +133,9 @@ class MapState:
         """
         handled_events = 0
 
-        for event in self._event_reader.events(1):
+        # Workaround HTCONDOR-463
+        os.stat(self._event_log_path.as_posix())
+        for event in self._event_reader.events(0):
             handled_events += 1
 
             # skip the late materialization submit event

--- a/htmap/state.py
+++ b/htmap/state.py
@@ -15,6 +15,7 @@
 
 import datetime
 import logging
+import os
 import pickle
 import threading
 from pathlib import Path


### PR DESCRIPTION
The current implementation of HTMap doesn't work properly on AFS filesystems as it is affected by the bug in the JobEvenLog.events() Python binding reported here: [HTCONDOR-463](https://opensciencegrid.atlassian.net/browse/HTCONDOR-463)

Following the updates in that ticket, this patch applies the proposed workaround to make sure there is fresh data in the job event log file.