### PR TITLE
Include tests in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE README.md
 include requirements.txt
+recursive-include tests *.py


### PR DESCRIPTION
This PR modifies `MANIFEST.in` to include the `tests/` directory in the source distribution (tarball); this allows downstream testing of binary packages built from the tarball.