### PR TITLE
Replace autocompletion keyword with shell_complete

### DIFF
--- a/htmap/cli.py
+++ b/htmap/cli.py
@@ -256,7 +256,7 @@ def _multi_tag_args(func):
             "tags",
             nargs=-1,
             callback=_read_tags_from_stdin,
-            autocompletion=_autocomplete_tag,
+            shell_complete=_autocomplete_tag,
             required=False,
         ),
         click.option(
@@ -510,7 +510,7 @@ def reasons(tags, pattern, all):
     click.echo("\n".join(reps))
 
 
-tag = click.argument("tag", autocompletion=_autocomplete_tag)
+tag = click.argument("tag", shell_complete=_autocomplete_tag)
 
 component = click.argument("component", type=int,)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages =
     htmap
     htmap.run
 install_requires =
-    click>=7.0
+    click>=8.0
     click-didyoumean>=0.0.3
     cloudpickle>=1.4
     halo>=0.0.30


### PR DESCRIPTION
This PR fixes #244 with a naive replacement of `autocompletion` with `shell_complete` as a keyword argument to `click.argument()`.