### PR TITLE
Fix CI part one

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
-        htcondor-version: ["8.8", "9.0", "9.1"]
-        exclude:
-          - htcondor-version: "8.8"
-            python-version: "3.8"
+        htcondor-version: ["9.0", "9.1"]
     steps:
       - uses: actions/checkout@v2
       - name: Build the Docker image for testing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,11 @@ repos:
       - id: mixed-line-ending
       - id: check-case-conflict
       - id: forbid-new-submodules
-  - repo: https://github.com/psf/black
-    rev: 19.10b0
-    hooks:
-      - id: black
+  # broken:
+  # - repo: https://github.com/psf/black
+  #   rev: 19.10b0
+  #   hooks:
+  #     - id: black
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.7.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,11 @@ repos:
   #   rev: 19.10b0
   #   hooks:
   #     - id: black
-  - repo: https://github.com/asottile/blacken-docs
-    rev: v1.7.0
-    hooks:
-      - id: blacken-docs
+  # broken:
+  # - repo: https://github.com/asottile/blacken-docs
+  #   rev: v1.7.0
+  #   hooks:
+  #     - id: blacken-docs
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v2.0.0
     hooks:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,11 +37,7 @@ RUN : \
  && apt-get -y install --no-install-recommends vim less git gnupg wget ca-certificates locales graphviz pandoc strace \
  && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
  && locale-gen \
- && if expr "$HTCONDOR_VERSION" : '8\.[89]' >/dev/null; then \
-        wget -qO - https://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -; \
-    else \
-        wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-$HTCONDOR_VERSION-Key | apt-key add -; \
-    fi \
+ && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-$HTCONDOR_VERSION-Key | apt-key add - \
  && eval $(grep '^VERSION_CODENAME=' /etc/os-release) \
  && echo "deb https://research.cs.wisc.edu/htcondor/repo/debian/${HTCONDOR_VERSION} ${VERSION_CODENAME} main" >> /etc/apt/sources.list.d/htcondor.list \
  && apt-get -y update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,8 @@ RUN : \
     else \
         wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-$HTCONDOR_VERSION-Key | apt-key add -; \
     fi \
- && echo "deb https://research.cs.wisc.edu/htcondor/repo/debian/${HTCONDOR_VERSION} buster main" >> /etc/apt/sources.list.d/htcondor.list \
+ && eval $(grep '^VERSION_CODENAME=' /etc/os-release) \
+ && echo "deb https://research.cs.wisc.edu/htcondor/repo/debian/${HTCONDOR_VERSION} ${VERSION_CODENAME} main" >> /etc/apt/sources.list.d/htcondor.list \
  && apt-get -y update \
  && apt-get -y install --no-install-recommends htcondor \
  && condor_version | grep -E '^[$]CondorVersion: '"${HTCONDOR_VERSION}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,8 +37,8 @@ RUN : \
  && apt-get -y install --no-install-recommends vim less git gnupg wget ca-certificates locales graphviz pandoc strace \
  && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
  && locale-gen \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-$HTCONDOR_VERSION-Key | apt-key add - \
- && eval $(grep '^VERSION_CODENAME=' /etc/os-release) \
+ && wget -qO - "https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-$HTCONDOR_VERSION-Key" | apt-key add - \
+ && eval "$(grep '^VERSION_CODENAME=' /etc/os-release)" \
  && echo "deb https://research.cs.wisc.edu/htcondor/repo/debian/${HTCONDOR_VERSION} ${VERSION_CODENAME} main" >> /etc/apt/sources.list.d/htcondor.list \
  && apt-get -y update \
  && apt-get -y install --no-install-recommends htcondor \


### PR DESCRIPTION
Use correct Debian codename for the repo -- the underlying python container switched from "buster" to "bullseye". This PR grabs the codename dynamically instead of hardcoding "buster".

Part one because I also have to fix the Dockerfile to understand the new 9.x versioning scheme.